### PR TITLE
Official Images suggestions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,21 +6,20 @@
 
 FROM debian:7
 
-
-# Work from /tmp
-WORKDIR /tmp
+ENV AEROSPIKE_VERSION 3.4.1
+ENV AEROSPIKE_SHA256 b37abccf7003d8193cb594ac8d693e42df6b94dca83fb2c21df6ef8041d92642
 
 # Install Aerospike
 RUN \
   apt-get update -y \
   && apt-get install -y wget logrotate ca-certificates \
-  && wget https://www.aerospike.com/artifacts/aerospike-server-community/3.4.1/aerospike-server-community-3.4.1-debian7.tgz \
-  && wget -O /tmp/CHECKSUM https://www.aerospike.com/artifacts/aerospike-server-community/3.4.1/aerospike-server-community-3.4.1-debian7.tgz.sha256  \
-  && sha256sum -c /tmp/CHECKSUM \
-  && tar xzf aerospike-server-community-*.tgz \
-  && cd aerospike-server-community-* \
-  && dpkg -i aerospike-server-* \
-  && rm -rf /var/lib/apt/lists/*
+  && wget "https://www.aerospike.com/artifacts/aerospike-server-community/${AEROSPIKE_VERSION}/aerospike-server-community-${AEROSPIKE_VERSION}-debian7.tgz" -O aerospike-server.tgz \
+  && echo "$AEROSPIKE_SHA256 *aerospike-server.tgz" | sha256sum -c - \
+  && mkdir aerospike \
+  && tar xzf aerospike-server.tgz --strip-components=1 -C aerospike \
+  && dpkg -i aerospike/aerospike-server-*.deb \
+  && apt-get purge -y --auto-remove wget ca-certificates \
+  && rm -rf aerospike-server.tgz aerospike /var/lib/apt/lists/*
 
 # Add the Aerospike configuration specific to this dockerfile
 ADD aerospike.conf /etc/aerospike/aerospike.conf

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+url='git://github.com/aerospike/aerospike-server.docker'
+
+echo '# maintainer: Lucien Volmar <lucien@aerospike.com> (@volmarl)'
+
+commit="$(git log -1 --format='format:%H' -- .)"
+fullVersion="$(grep -m1 'ENV AEROSPIKE_VERSION ' Dockerfile | cut -d' ' -f3)"
+
+versionAliases=()
+# uncomment if you want aliases like: 3, 3.4 for 3.4.1
+#while [ "${fullVersion%.*}" != "$fullVersion" ]; do
+#	versionAliases+=( $fullVersion )
+#	fullVersion="${fullVersion%.*}"
+#done
+versionAliases+=( $fullVersion latest )
+
+echo
+for va in "${versionAliases[@]}"; do
+	echo "$va: ${url}@${commit}"
+done

--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+fullVersion="$(curl -sSL 'https://www.aerospike.com/artifacts/aerospike-server-community/' | grep -E '<a href="[0-9.-]+/"' | sed -r 's!.*<a href="([0-9.-]+)/".*!\1!' | sort -V | tail -1)"
+
+sha256="$(curl -sSL "https://www.aerospike.com/artifacts/aerospike-server-community/${fullVersion}/aerospike-server-community-${fullVersion}-debian7.tgz.sha256" | cut -d' ' -f1)"
+
+set -x
+sed -ri '
+	s/^(ENV AEROSPIKE_VERSION) .*/\1 '"$fullVersion"'/;
+	s/^(ENV AEROSPIKE_SHA256) .*/\1 '"$sha256"'/;
+' Dockerfile


### PR DESCRIPTION
The updates to the Dockerfile are to help cleanup the deb and deps, as well as increase "security" by embedding the SHA into the dockerfile (the update script in the second commit will help keep this in sync with the version).

The update script uses `https://www.aerospike.com/artifacts/aerospike-server-community/` to find the newest version of aerospike so that you only have to `./update.sh`, `git add -p`. and `git commit` when an version bump is needed.

The `generate-stackbrew-library.sh` is to help in creating the PR to [official-images](https://github.com/docker-library/official-images).  Once you commit a version bump or other updates to aerospike, just run `../aerospike-server.docker/generate-stackbrew-library.sh > library/aerospike` from you clone of official-images (adjusting relative path as necessary).  I also included a commented out section if you want to have aliases of `3` and `3.4` for `3.4.1` (which will naturally follow 3.4.x when released).