### PR TITLE
Dockerfile issue 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,8 @@ RUN \
   && apt-get purge -y --auto-remove wget ca-certificates \
   && rm -rf aerospike-server.tgz aerospike /var/lib/apt/lists/*
 
-# Add the Aerospike configuration specific to this dockerfile
-ADD aerospike.conf /etc/aerospike/aerospike.conf
+# Copy the Aerospike configuration specific to this dockerfile
+COPY aerospike.conf /etc/aerospike/aerospike.conf
 
 # Mount the Aerospike data directory
 VOLUME ["/opt/aerospike/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,10 @@ VOLUME ["/opt/aerospike/data"]
 #
 EXPOSE 3000 3001 3002 3003
 
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+
 # Run commands in the container as the aerospike user by default
 USER aerospike
 
-# Execute the run script in foreground mode
-CMD ["/usr/bin/asd","--foreground"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["asd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM debian:7
 ENV AEROSPIKE_VERSION 3.6.1 
 ENV AEROSPIKE_SHA256 28207fe6b79f42d2901657a4e05560198f452e2a1a91f018f9c564bf1f808e28 
 
-# Install Aerospike
+# Install Aerospike with a static UID/GID for the aerospike user/group
 RUN \
   apt-get update -y \
   && apt-get install -y wget logrotate ca-certificates \
@@ -17,6 +17,8 @@ RUN \
   && echo "$AEROSPIKE_SHA256 *aerospike-server.tgz" | sha256sum -c - \
   && mkdir aerospike \
   && tar xzf aerospike-server.tgz --strip-components=1 -C aerospike \
+  && groupadd -g 24183 aerospike \
+  && useradd -r -u 24183 -d /opt/aerospike -g aerospike aerospike \
   && dpkg -i aerospike/aerospike-server-*.deb \
   && apt-get purge -y --auto-remove wget ca-certificates \
   && rm -rf aerospike-server.tgz aerospike /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,8 @@ VOLUME ["/opt/aerospike/data"]
 #
 EXPOSE 3000 3001 3002 3003
 
+# Run commands in the container as the aerospike user by default
+USER aerospike
+
 # Execute the run script in foreground mode
 CMD ["/usr/bin/asd","--foreground"]

--- a/aerospike.conf
+++ b/aerospike.conf
@@ -2,8 +2,8 @@
 
 # This stanza must come first.
 service {
-	user root
-	group root
+	user aerospike
+	group aerospike
 	paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
 	pidfile /var/run/aerospike/asd.pid
 	service-threads 4

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+# if command starts with an option, prepend asd
+if [ "${1:0:1}" = '-' ]; then
+	set -- asd "$@"
+fi
+
+# if asd is specified for the command, start it with any given options
+if [ "$1" = 'asd' ]; then
+	# asd should always run in the foreground
+	set -- "$@" --foreground
+
+	# check data volume ownership
+	if [ ! -O /opt/aerospike/data ]; then
+		echo 'ERROR: /opt/aerospike/data is not owned by the aerospike user'
+		echo 'This should only happen with a volume mounted at /opt/aerospike/data'
+		echo
+		echo "To fix, use the following docker run command and"
+		echo "replace IMAGEID and VOLUME_BIND with the proper values:"
+		echo "docker run -u root -v VOLUME_BIND IMAGEID chown -R 24183:24183 /opt/aerospike"
+
+		exit 1
+	fi
+fi
+
+# the command isn't asd so run the command the user specified
+exec "$@"


### PR DESCRIPTION
This will resolve #7

I've incorporated all the changes I suggested.  I kept tianon's ENTRYPOINT tip in mind as well.  I looked at several other official repositories to try to implement it correctly.

I've noticed that many entrypoint scripts use a chown to fix possible UID/GID issues before starting the main service process.  Since I've set the container to run as the aerospike user, that technique won't work.  I think using a static random high number UID/GID is a good alternative so that the container user can be non-root by default.
