### PR TITLE
Non root docker config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,6 @@ COPY aerospike.template.conf /etc/aerospike/aerospike.template.conf
 COPY entrypoint.sh /entrypoint.sh
 # Mount the Aerospike data directory
 VOLUME ["/opt/aerospike/data"]
-
 # VOLUME ["/etc/aerospike/"]
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ ENV AEROSPIKE_VERSION 4.5.3.3
 ENV AEROSPIKE_SHA256 840eec1223319bc82b8f7db6a155631bc2f991b5de975c45042c90ce39b3d058
 
 # Install Aerospike Server and Tools
-
-
 RUN \
   apt-get update -y \
   && apt-get install -y wget python lua5.2 gettext-base \
@@ -22,7 +20,19 @@ RUN \
   && dpkg -i aerospike/aerospike-server-*.deb \
   && dpkg -i aerospike/aerospike-tools-*.deb \
   && mkdir -p /var/log/aerospike/ \
+  && mkdir -p /var/log/aerospike/ \
+  && chgrp -R 0 /var/log/aerospike \
   && mkdir -p /var/run/aerospike/ \
+  && chgrp -R 0 /var/run/aerospike \
+  && chmod -R g+rwX /var/run/aerospike \
+  && chgrp -R 0 /opt/aerospike/smd \
+  && chmod -R g+rwX /opt/aerospike/smd \
+  && chgrp -R 0 /opt/aerospike/usr \
+  && chmod -R g+rwX /opt/aerospike/usr \
+  && chgrp -R 0 /opt/aerospike/data \
+  && chmod -R g+rwX /opt/aerospike/data \
+  && chgrp -R 0 /etc/aerospike \
+  && chmod -R g+rwX /etc/aerospike \
   && rm -rf aerospike-server.tgz aerospike /var/lib/apt/lists/* \
   && rm -rf /opt/aerospike/lib/java \
   && dpkg -r wget ca-certificates openssl xz-utils\
@@ -38,6 +48,7 @@ COPY aerospike.template.conf /etc/aerospike/aerospike.template.conf
 COPY entrypoint.sh /entrypoint.sh
 # Mount the Aerospike data directory
 VOLUME ["/opt/aerospike/data"]
+
 # VOLUME ["/etc/aerospike/"]
 
 

--- a/aerospike.template.conf
+++ b/aerospike.template.conf
@@ -2,8 +2,8 @@
 
 # This stanza must come first.
 service {
-	user root
-	group root
+	user ${APP_USER}
+	group ${APP_GROUP}
 	paxos-single-replica-limit 1 # Number of nodes where the replica count is automatically reduced to 1.
 	pidfile /var/run/aerospike/asd.pid
 	service-threads ${SERVICE_THREADS}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,6 @@ export REPL_FACTOR=${REPL_FACTOR:-2}
 export MEM_GB=${MEM_GB:-1}
 export DEFAULT_TTL=${DEFAULT_TTL:-30d}
 export STORAGE_GB=${STORAGE_GB:-4}
-export STORAGE_GB=${STORAGE_GB:-4}
 export APP_USER=$(whoami)
 export APP_GROUP=${APP_GROUP:=root}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,6 +19,9 @@ export REPL_FACTOR=${REPL_FACTOR:-2}
 export MEM_GB=${MEM_GB:-1}
 export DEFAULT_TTL=${DEFAULT_TTL:-30d}
 export STORAGE_GB=${STORAGE_GB:-4}
+export STORAGE_GB=${STORAGE_GB:-4}
+export APP_USER=$(whoami)
+export APP_GROUP=${APP_GROUP:=root}
 
 # Fill out conffile with above values
 if [ -f /etc/aerospike/aerospike.template.conf ]; then


### PR DESCRIPTION
Allows creation of a docker image where the container is being run using a non-root user which is a member of the root group. This is the way things are done on OpenShift. Keep content in this branch.