### PR TITLE
Fix curl silently failing with a non 5xx status code is returned by the server

### DIFF
--- a/community/ubuntu22.04/Dockerfile
+++ b/community/ubuntu22.04/Dockerfile
@@ -82,8 +82,9 @@ RUN \
       echo "Unsuported architecture - ${ARCH}" >&2; \
       exit 1; \
     fi; \
-    if ! curl -fsSL "${pkg_link}" --output aerospike-server.tgz; then \
+    if [ $(curl -fsSL -w '%{http_code}' "${pkg_link}" --output aerospike-server.tgz) != "200" ]; then \
       echo "Could not fetch pkg - ${pkg_link}" >&2; \
+      cat aerospike-server.tgz; \
       exit 1; \
     fi; \
     echo "${sha256} aerospike-server.tgz" | sha256sum -c -; \

--- a/enterprise/ubuntu22.04/Dockerfile
+++ b/enterprise/ubuntu22.04/Dockerfile
@@ -82,8 +82,9 @@ RUN \
       echo "Unsuported architecture - ${ARCH}" >&2; \
       exit 1; \
     fi; \
-    if ! curl -fsSL "${pkg_link}" --output aerospike-server.tgz; then \
+    if [ $(curl -fsSL -w '%{http_code}' "${pkg_link}" --output aerospike-server.tgz) != "200" ]; then \
       echo "Could not fetch pkg - ${pkg_link}" >&2; \
+      cat aerospike-server.tgz; \
       exit 1; \
     fi; \
     echo "${sha256} aerospike-server.tgz" | sha256sum -c -; \

--- a/federal/ubuntu22.04/Dockerfile
+++ b/federal/ubuntu22.04/Dockerfile
@@ -82,8 +82,9 @@ RUN \
       echo "Unsuported architecture - ${ARCH}" >&2; \
       exit 1; \
     fi; \
-    if ! curl -fsSL "${pkg_link}" --output aerospike-server.tgz; then \
+    if [ $(curl -fsSL -w '%{http_code}' "${pkg_link}" --output aerospike-server.tgz) != "200" ]; then \
       echo "Could not fetch pkg - ${pkg_link}" >&2; \
+      cat aerospike-server.tgz; \
       exit 1; \
     fi; \
     echo "${sha256} aerospike-server.tgz" | sha256sum -c -; \


### PR DESCRIPTION
For example:

if `pkg_link` is: 

```diff
-https://artifacts.aerospike.com/.../aerospike-server-federal_7.1.0.0_tools-11.0.0_ubuntu22.04_x86_64.tgz
+https://artifacts.aerospike.com/.../aerospike-server-federal_7.1.0.0_tools-11.0.0_ubuntu22.04_x86_65.tgz
```

The server returns an HTTP 300 Multiple Choice. 

This is causing issues in the new DOI build because there is an error and we can't figure out what it is

https://github.com/docker-library/meta/actions/runs/9319226426/job/25653282798