### PR TITLE
SERVER-619: make vendored as-tini-static install Docker Official Images compliant

### DIFF
--- a/lib/dockerfile_fragment_tini.docker
+++ b/lib/dockerfile_fragment_tini.docker
@@ -2,6 +2,16 @@
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -87,6 +87,23 @@ if not frag.endswith("\n"):
     frag += "\n"
 text = df_path.read_text()
 if "COPY static/tini/as-tini-static-amd64" in text:
+    # Self-heal older Dockerfiles that have tini COPY/RUN but missed ARG TARGETARCH.
+    if (
+        "cp \"/opt/aerospike-tini/as-tini-static-${TARGETARCH}\"" in text
+        and "ARG TARGETARCH" not in text
+    ):
+        lines = text.splitlines(keepends=True)
+        out = []
+        inserted = False
+        for line in lines:
+            if (not inserted) and line.startswith("RUN cp \"/opt/aerospike-tini/as-tini-static-${TARGETARCH}\""):
+                out.append("ARG TARGETARCH\n")
+                inserted = True
+            out.append(line)
+        if not inserted:
+            sys.stderr.write(f"{df_path}: could not insert ARG TARGETARCH before tini RUN\n")
+            sys.exit(1)
+        df_path.write_text("".join(out))
     raise SystemExit(0)
 lines = text.splitlines(keepends=True)
 out = []

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -74,11 +74,19 @@ function _sync_static_tini_to_target() {
     cp "${SCRIPT_DIR}/static/tini/as-tini-static-amd64" "${SCRIPT_DIR}/static/tini/as-tini-static-arm64" "${target}/static/tini/"
 }
 
-# Insert vendored-tini COPY/RUN after SHELL if missing (matches lib/dockerfile_fragment_tini.docker).
+# Ensure the vendored-tini block in the Dockerfile matches the canonical
+# fragment (lib/dockerfile_fragment_tini.docker). Three cases:
+#   1. Block missing entirely  -> insert fragment after SHELL.
+#   2. Old-form block present  -> replace whole block (comments + COPY +
+#      optional `ARG TARGETARCH` + RUN cp) with the fragment. Old form
+#      relies on BuildKit to auto-populate ${TARGETARCH}, which the legacy
+#      builder used by Docker Official Images (DOI) does not, breaking
+#      under `set -u`. The new fragment falls back to `uname -m`.
+#   3. New-form block already present -> no-op (idempotent).
 function _dockerfile_ensure_vendored_tini() {
     local df=$1
     python3 - "${df}" "${SCRIPT_DIR}/lib/dockerfile_fragment_tini.docker" <<'PY'
-import pathlib, sys
+import pathlib, re, sys
 
 df_path = pathlib.Path(sys.argv[1])
 frag_path = pathlib.Path(sys.argv[2])
@@ -86,25 +94,37 @@ frag = frag_path.read_text()
 if not frag.endswith("\n"):
     frag += "\n"
 text = df_path.read_text()
-if "COPY static/tini/as-tini-static-amd64" in text:
-    # Self-heal older Dockerfiles that have tini COPY/RUN but missed ARG TARGETARCH.
-    if (
-        "cp \"/opt/aerospike-tini/as-tini-static-${TARGETARCH}\"" in text
-        and "ARG TARGETARCH" not in text
-    ):
-        lines = text.splitlines(keepends=True)
-        out = []
-        inserted = False
-        for line in lines:
-            if (not inserted) and line.startswith("RUN cp \"/opt/aerospike-tini/as-tini-static-${TARGETARCH}\""):
-                out.append("ARG TARGETARCH\n")
-                inserted = True
-            out.append(line)
-        if not inserted:
-            sys.stderr.write(f"{df_path}: could not insert ARG TARGETARCH before tini RUN\n")
-            sys.exit(1)
-        df_path.write_text("".join(out))
+
+# Case 3: already in the new (DOI-safe) form.
+if 'as-tini-static-${arch}' in text:
     raise SystemExit(0)
+
+# Case 2: replace the entire old tini block with the canonical fragment.
+if "COPY static/tini/as-tini-static-amd64" in text:
+    pattern = re.compile(
+        r"(?ms)"
+        # leading tini-related comment lines (any contiguous run of `# ...` lines)
+        r"(?:^#[^\n]*\n)*"
+        # the COPY line
+        r"^COPY static/tini/as-tini-static-amd64[^\n]*\n"
+        # optional bare `ARG TARGETARCH` (old form had no default)
+        r"(?:^ARG TARGETARCH[^\n]*\n)?"
+        # RUN cp ... start line
+        r"^RUN cp \"/opt/aerospike-tini/as-tini-static-\$\{TARGETARCH\}\"[^\n]*\n"
+        # any number of leading-whitespace continuation lines
+        r"(?:^[ \t][^\n]*\n)*"
+    )
+    text2, n = pattern.subn(frag, text, count=1)
+    if n != 1:
+        sys.stderr.write(
+            f"{df_path}: could not match existing tini block to replace "
+            "(file format unexpected)\n"
+        )
+        sys.exit(1)
+    df_path.write_text(text2)
+    raise SystemExit(0)
+
+# Case 1: insert the fragment after the SHELL line.
 lines = text.splitlines(keepends=True)
 out = []
 inserted = False

--- a/releases/7.1/community/ubi9/Dockerfile
+++ b/releases/7.1/community/ubi9/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/7.1/community/ubuntu22.04/Dockerfile
+++ b/releases/7.1/community/ubuntu22.04/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/7.1/enterprise/ubi9/Dockerfile
+++ b/releases/7.1/enterprise/ubi9/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/7.1/enterprise/ubuntu22.04/Dockerfile
+++ b/releases/7.1/enterprise/ubuntu22.04/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/7.1/federal/ubi9/Dockerfile
+++ b/releases/7.1/federal/ubi9/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/7.1/federal/ubuntu22.04/Dockerfile
+++ b/releases/7.1/federal/ubuntu22.04/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/7.2/community/ubi9/Dockerfile
+++ b/releases/7.2/community/ubi9/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/7.2/community/ubuntu24.04/Dockerfile
+++ b/releases/7.2/community/ubuntu24.04/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/7.2/enterprise/ubi9/Dockerfile
+++ b/releases/7.2/enterprise/ubi9/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/7.2/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/7.2/enterprise/ubuntu24.04/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/7.2/federal/ubi9/Dockerfile
+++ b/releases/7.2/federal/ubi9/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/7.2/federal/ubuntu24.04/Dockerfile
+++ b/releases/7.2/federal/ubuntu24.04/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/8.0/community/ubi9/Dockerfile
+++ b/releases/8.0/community/ubi9/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/8.0/community/ubuntu24.04/Dockerfile
+++ b/releases/8.0/community/ubuntu24.04/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/8.0/enterprise/ubi9/Dockerfile
+++ b/releases/8.0/enterprise/ubi9/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/8.0/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/8.0/enterprise/ubuntu24.04/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/8.0/federal/ubi9/Dockerfile
+++ b/releases/8.0/federal/ubi9/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/8.0/federal/ubuntu24.04/Dockerfile
+++ b/releases/8.0/federal/ubuntu24.04/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/8.1/community/ubi10/Dockerfile
+++ b/releases/8.1/community/ubi10/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/8.1/community/ubuntu24.04/Dockerfile
+++ b/releases/8.1/community/ubuntu24.04/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/8.1/enterprise/ubi10/Dockerfile
+++ b/releases/8.1/enterprise/ubi10/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/8.1/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/8.1/enterprise/ubuntu24.04/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/8.1/federal/ubi10/Dockerfile
+++ b/releases/8.1/federal/ubi10/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools

--- a/releases/8.1/federal/ubuntu24.04/Dockerfile
+++ b/releases/8.1/federal/ubuntu24.04/Dockerfile
@@ -35,8 +35,18 @@ SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 # COPY avoids RUN-time fetch from GitHub (Docker Official / air-gapped / reproducible builds).
 # hadolint ignore=DL3042
 COPY static/tini/as-tini-static-amd64 static/tini/as-tini-static-arm64 /opt/aerospike-tini/
-ARG TARGETARCH
-RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static && chmod +x /usr/bin/as-tini-static \
+# TARGETARCH is auto-populated by BuildKit. The empty default keeps the
+# legacy builder used by Docker Official Images (DOI) from tripping `set -u`,
+# and the RUN below falls back to `uname -m`, so the same Dockerfile works on
+# both BuildKit and the legacy builder, on Debian/Ubuntu and UBI/RHEL alike.
+ARG TARGETARCH=
+RUN case "${TARGETARCH:-$(uname -m)}" in \
+        amd64 | x86_64) arch=amd64 ;; \
+        arm64 | aarch64) arch=arm64 ;; \
+        *) echo "ERROR: unsupported arch ${TARGETARCH:-$(uname -m)} for as-tini-static" >&2; exit 1 ;; \
+    esac \
+    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
+    && chmod +x /usr/bin/as-tini-static \
     && rm -rf /opt/aerospike-tini
 
 # Install Aerospike Server and Tools


### PR DESCRIPTION
## Problem

The Docker Official Images (DOI) rebuild of `aerospike:ee-8.1.2.0` fails at Step 12/19 of the Dockerfile build with:

```
/bin/bash: line 1: TARGETARCH: unbound variable
```

See [docker-library/official-images PR #21294](https://github.com/docker-library/official-images/pull/21294), [run 24746884738 / job 72400793944](https://github.com/docker-library/official-images/actions/runs/24746884738/job/72400793944).

## Root cause

DOI builds with `bashbrew`, which uses the **legacy Docker builder, not BuildKit** (the failing log explicitly states `BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0 environment-variable.`). The vendored `as-tini-static` install step relied on `TARGETARCH` being auto-populated:

```Dockerfile
ARG TARGETARCH
RUN cp "/opt/aerospike-tini/as-tini-static-${TARGETARCH}" /usr/bin/as-tini-static ...
```

`TARGETARCH` is a **BuildKit predefined automatic platform ARG**. The legacy builder does not auto-populate it, so `ARG TARGETARCH` declares the variable with no value. Combined with `SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]` (`set -u`), expanding `${TARGETARCH}` aborts the build.

Any DOI-tracked Dockerfile that depends on BuildKit-only features is non-compliant by design.

## Industry-standard fix

Detect the architecture **inside the RUN step**, with `TARGETARCH` only as a hint when present. Pattern works under both the legacy builder (DOI) and BuildKit, on both Debian/Ubuntu and UBI/RHEL, and stays under `set -u`:

```Dockerfile
ARG TARGETARCH=
RUN case "${TARGETARCH:-$(uname -m)}" in \
        amd64 | x86_64) arch=amd64 ;; \
        arm64 | aarch64) arch=arm64 ;; \
        *) echo "ERROR: unsupported arch ..." >&2; exit 1 ;; \
    esac \
    && cp "/opt/aerospike-tini/as-tini-static-${arch}" /usr/bin/as-tini-static \
    && chmod +x /usr/bin/as-tini-static \
    && rm -rf /opt/aerospike-tini
```

The empty default (`ARG TARGETARCH=`) keeps `set -u` happy; `${TARGETARCH:-$(uname -m)}` preserves BuildKit's auto value when present and falls back to `uname -m` on the legacy builder; the explicit `case` rejects unknown architectures with a clear error.

## Changes

- **`lib/dockerfile_fragment_tini.docker`**: rewrite to the portable arch-detect form above.
- **`lib/update.sh`** (`_dockerfile_ensure_vendored_tini`): extend the existing self-heal so it now (a) no-ops when the new form is already present, (b) replaces the entire old-form block (comments + `COPY` + optional `ARG TARGETARCH` + `RUN cp` continuation) with the canonical fragment, and (c) still inserts the fragment after `SHELL` when missing entirely. Idempotent; safe to re-run.
- **`releases/**/Dockerfile`** (22 files): regenerated through the new self-heal, yielding a per-file diff identical to what the full `-g` emit path produces (verified by diffing the in-repo block against `lib/dockerfile_fragment_tini.docker` — IDENTICAL).

## Verification

Local checks (mirroring `reviewdog.yml` CI):

- `shellcheck lib/update.sh docker-build.sh lib/*.sh scripts/{deb,rpm}/install.sh` — clean.
- `shfmt -d lib/update.sh docker-build.sh lib/*.sh` — clean.
- `hadolint --ignore DL3008 releases/*/*/*/Dockerfile` (matching CI) — clean on all 22 generated Dockerfiles.
- `actionlint` — clean.
- Idempotency: re-running `_dockerfile_ensure_vendored_tini` on every `releases/**/Dockerfile` produces zero additional diff.

Semantic test of the new RUN body under `bash -Eeuo pipefail`:

| Scenario | Behaviour |
|---|---|
| `TARGETARCH` unset (legacy builder, DOI) | Falls back to `uname -m`, resolves arch, copies binary. |
| `TARGETARCH=arm64` (BuildKit, multi-arch) | Resolves to arm64, copies arm64 binary. |
| `TARGETARCH=ppc64le` (unsupported) | Emits clear error, exits 1. |

The Docker Build CI workflow's `generate-check` job (`./docker-build.sh -g <lineage>` followed by `git diff --stat`) will produce zero diff because the in-repo Dockerfiles already contain exactly what the fragment emits.

## Test plan

- [ ] CI `reviewdog` (shellcheck / shfmt / hadolint / actionlint) all green.
- [ ] CI `Docker Build / Generate (no diff)` passes.
- [ ] CI `Docker Build / Build and test` passes for all four lineages on both `amd64` and `arm64`.
- [ ] Once merged, the next DOI PR build of `aerospike:ee-8.1.2.0` succeeds at Step 12.