### PR TITLE
Fix Snyk Dockerfile parsing: restore blank line after openssl upgrade block

### DIFF
--- a/lib/update.sh
+++ b/lib/update.sh
@@ -291,7 +291,7 @@ function _dockerfile_refresh_openssl_block() {
             if (/^RUN \\/) { next }
             if (/^[ \t]/)  { next }
             if (/^$/)      { next }
-            emit_new_block(); state = "done"; print; next
+            emit_new_block(); print ""; state = "done"; print; next
         }
         { print }
         END { if (state == "consuming") emit_new_block() }

--- a/releases/7.2/community/ubuntu24.04/Dockerfile
+++ b/releases/7.2/community/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/7.2/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/7.2/enterprise/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/7.2/federal/ubuntu24.04/Dockerfile
+++ b/releases/7.2/federal/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.0/community/ubuntu24.04/Dockerfile
+++ b/releases/8.0/community/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.0/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/8.0/enterprise/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.0/federal/ubuntu24.04/Dockerfile
+++ b/releases/8.0/federal/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.1/community/ubuntu24.04/Dockerfile
+++ b/releases/8.1/community/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.1/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/8.1/enterprise/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.1/federal/ubuntu24.04/Dockerfile
+++ b/releases/8.1/federal/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \


### PR DESCRIPTION
## Problem

Snyk's static Dockerfile scanner was continuing to report:

```
Introduced through: openssl/libssl3t64@3.0.13-0ubuntu3.9
Fixed in: openssl/libssl3t64@3.0.13-0ubuntu3.11
```

…even though all ubuntu24.04 Dockerfiles already contain an explicit
`apt-get install libssl3t64=3.0.13-0ubuntu3.11` upgrade block.

The root cause was a missing blank line between the openssl upgrade `RUN`
block and the `# Install Aerospike Server and Tools` comment, introduced
in the previous commit (#98). Without that separator, Snyk's Dockerfile
parser fails to attribute the explicit version pin as an upgrade of the
base-image package, and continues to report the `ubuntu:24.04` base
image version (`3.0.13-0ubuntu3.9`) as the installed version.

Note: container image scanning (`snyk container test`) was already clean
— this only affected Snyk's static Dockerfile analysis mode.

## Changes

- **All 9 ubuntu24.04 Dockerfiles** (community/enterprise/federal ×
  7.2/8.0/8.1): restore the blank line between the openssl upgrade block
  and the install block anchor so Snyk's parser correctly resolves the
  upgrade.

- **`lib/update.sh` — `_dockerfile_refresh_openssl_block`**: add
  `print ""` after `emit_new_block()` in the replace-in-place path so
  future `docker-build.sh` runs (without `-g`) cannot reintroduce the
  missing separator.

## Test plan

- [ ] Rebuild ubuntu24.04 images and re-run `snyk container test` —
      confirm no `openssl/libssl3t64` findings
- [ ] Trigger Snyk Dockerfile rescan via GitHub integration — confirm
      finding for `libssl3t64@3.0.13-0ubuntu3.9` is resolved
- [ ] Run `docker-build.sh -t 8.1 -d ubuntu24.04` (in-place update
      mode) and verify the blank line is preserved in generated Dockerfiles