### PR TITLE
Revert to bbf7b1f (Hotfixes 7.1.0.25, 7.2.0.19, 8.0.0.17, 8.1.2.2)

### DIFF
--- a/lib/emit.sh
+++ b/lib/emit.sh
@@ -151,30 +151,6 @@ RUN \
   rm -rf /var/cache/yum /var/cache/dnf'
     fi
 
-    # --- OpenSSL security upgrade (Ubuntu distros only) ---
-    local openssl_upgrade_run=""
-    if [ "${distro}" = "ubuntu24.04" ]; then
-        openssl_upgrade_run='# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
-  ; \
-  rm -rf /var/lib/apt/lists/*'
-    elif [ "${distro}" = "ubuntu22.04" ]; then
-        openssl_upgrade_run='# Upgrade openssl/libssl3 and libgnutls30 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30=3.7.3-4ubuntu1.9 \
-    libssl3=3.0.2-0ubuntu1.25 \
-    openssl=3.0.2-0ubuntu1.25 \
-  ; \
-  rm -rf /var/lib/apt/lists/*'
-    fi
-
     # --- Placeholder substitution for package URLs/SHAs ---
     # TGZ scripts use __PKG_URL_* / __PKG_SHA_* placeholders.
     # Native scripts use __SERVER_URL_* / __SERVER_SHA_* placeholders.
@@ -253,11 +229,6 @@ HEADER
 
         echo "${base_deps_run}"
         echo ""
-
-        if [ -n "${openssl_upgrade_run}" ]; then
-            echo "${openssl_upgrade_run}"
-            echo ""
-        fi
 
         # For local native package builds, COPY the pre-staged package file into
         # /tmp/aerospike/ before the install RUN block (the install script detects

--- a/lib/emit.sh
+++ b/lib/emit.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
-# Dockerfile generation: emit header + base-deps RUN block + OpenSSL upgrade RUN block
-# (Ubuntu only) + inlined install RUN block + footer.
+# Dockerfile generation: emit header + base-deps RUN block + inlined install RUN block + footer.
 # Install logic lives in scripts/deb/install.sh and scripts/rpm/install.sh and is
 # converted to a RUN \ continuation block by _sh_to_dockerfile_run (lib/sh_to_dockerfile_run.sh).
 # Package URL/SHA placeholders in the install scripts are substituted with actual
 # values fetched from the artifact server at generation time (no ARG indirection).
-# OpenSSL/TLS upgrade versions are defined in lib/support.sh (support_get_openssl_upgrade_block).
 # Copyright 2014-2025 Aerospike, Inc. Licensed under Apache-2.0. See LICENSE.
 # Dependencies: lib/log.sh, lib/support.sh, lib/fetch.sh, lib/sh_to_dockerfile_run.sh
 # Fragments:    lib/dockerfile_fragment_footer.docker
@@ -14,10 +12,9 @@ set -Eeuo pipefail
 
 # generate_dockerfile lineage distro edition version tools_version
 #
-# Emits a Dockerfile with up to three RUN blocks:
+# Emits a Dockerfile with two RUN blocks:
 #   1. Base runtime deps (apt-get/microdnf; ca-certificates, procps).
-#   2. OpenSSL/TLS security upgrade (Ubuntu distros only; versions from support_get_openssl_upgrade_block).
-#   3. All install logic inlined as a RUN \ block with hardcoded package URLs
+#   2. All install logic inlined as a RUN \ block with hardcoded package URLs
 #      and SHAs (substituted from placeholders in scripts/{deb,rpm}/install.sh).
 # No COPY of install.sh: DOI's bashbrew build context only includes files committed
 # in the upstream directory; install.sh is not among them.
@@ -155,9 +152,28 @@ RUN \
     fi
 
     # --- OpenSSL security upgrade (Ubuntu distros only) ---
-    # Versions are defined in lib/support.sh (support_get_openssl_upgrade_block).
-    local openssl_upgrade_run
-    openssl_upgrade_run=$(support_get_openssl_upgrade_block "${distro}")
+    local openssl_upgrade_run=""
+    if [ "${distro}" = "ubuntu24.04" ]; then
+        openssl_upgrade_run='# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
+RUN \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
+    libssl3t64=3.0.13-0ubuntu3.11 \
+    openssl=3.0.13-0ubuntu3.11 \
+  ; \
+  rm -rf /var/lib/apt/lists/*'
+    elif [ "${distro}" = "ubuntu22.04" ]; then
+        openssl_upgrade_run='# Upgrade openssl/libssl3 and libgnutls30 to patched versions
+RUN \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+    libgnutls30=3.7.3-4ubuntu1.9 \
+    libssl3=3.0.2-0ubuntu1.25 \
+    openssl=3.0.2-0ubuntu1.25 \
+  ; \
+  rm -rf /var/lib/apt/lists/*'
+    fi
 
     # --- Placeholder substitution for package URLs/SHAs ---
     # TGZ scripts use __PKG_URL_* / __PKG_SHA_* placeholders.

--- a/lib/support.sh
+++ b/lib/support.sh
@@ -8,7 +8,7 @@ set -Eeuo pipefail
 source lib/log.sh
 
 # Supported release lineages (order preserved for build/test iteration)
-RELEASES="7.2 8.0 8.1"
+RELEASES="7.1 7.2 8.0 8.1"
 
 # Supported editions
 EDITIONS="community enterprise federal"
@@ -157,39 +157,6 @@ function support_platform_to_arch() {
     *)
         log_warn "unexpected platform '$1'"
         exit 1
-        ;;
-    esac
-}
-
-# Returns the OpenSSL/TLS security upgrade RUN block for Ubuntu distros (no trailing newline).
-# Returns empty string for non-Ubuntu distros (ubi9, ubi10).
-# This is the single source of truth for pinned versions — update here when a new patch lands.
-function support_get_openssl_upgrade_block() {
-    local distro=$1
-    case "${distro}" in
-    ubuntu24.04)
-        printf '%s' \
-            '# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
-  ; \
-  rm -rf /var/lib/apt/lists/*'
-        ;;
-    ubuntu22.04)
-        printf '%s' \
-            '# Upgrade openssl/libssl3 and libgnutls30 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30=3.7.3-4ubuntu1.9 \
-    libssl3=3.0.2-0ubuntu1.25 \
-    openssl=3.0.2-0ubuntu1.25 \
-  ; \
-  rm -rf /var/lib/apt/lists/*'
         ;;
     esac
 }

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# In-place Dockerfile update: refresh version label, OpenSSL upgrade block, and install block.
+# In-place Dockerfile update: refresh install block and patch version label.
 # Used by default (no -g flag).
 # Copyright 2014-2025 Aerospike, Inc. Licensed under Apache-2.0. See LICENSE.
 # Dependencies: lib/log.sh, lib/support.sh, lib/fetch.sh, lib/sh_to_dockerfile_run.sh
@@ -258,62 +258,6 @@ function _dockerfile_remove_vendored_tini() {
     ' "${df}" >"${tmp}" && mv "${tmp}" "${df}"
 }
 
-# _dockerfile_refresh_openssl_block df distro
-# Refreshes (or inserts) the OpenSSL/TLS security upgrade RUN block in a Dockerfile.
-# Version constants come from support_get_openssl_upgrade_block (lib/support.sh).
-# No-op for non-Ubuntu distros (ubi9, ubi10).
-function _dockerfile_refresh_openssl_block() {
-    local df=$1 distro=$2
-
-    local new_block
-    new_block=$(support_get_openssl_upgrade_block "${distro}")
-    [ -z "${new_block}" ] && return 0
-
-    local tmp nbf
-    tmp=$(mktemp)
-    nbf=$(mktemp)
-    # shellcheck disable=SC2064
-    trap "rm -f '${tmp}' '${nbf}'" RETURN
-
-    printf '%s\n' "${new_block}" >"${nbf}"
-
-    if grep -qF '# Upgrade openssl/' "${df}"; then
-        # Block already present: replace it with the canonical content.
-        awk -v nbf="${nbf}" '
-        function emit_new_block(    line) {
-            while ((getline line < nbf) > 0) print line
-            close(nbf)
-        }
-        BEGIN { state = "looking" }
-        state == "done" { print; next }
-        state == "looking" && /^# Upgrade openssl\// { state = "consuming"; next }
-        state == "consuming" {
-            if (/^RUN \\/) { next }
-            if (/^[ \t]/)  { next }
-            if (/^$/)      { next }
-            emit_new_block(); state = "done"; print; next
-        }
-        { print }
-        END { if (state == "consuming") emit_new_block() }
-        ' "${df}" >"${tmp}" && mv "${tmp}" "${df}"
-    else
-        # Block missing: insert it immediately before the install anchor.
-        awk -v nbf="${nbf}" '
-        function emit_new_block(    line) {
-            while ((getline line < nbf) > 0) print line
-            close(nbf)
-        }
-        BEGIN { inserted = 0 }
-        !inserted && /^# Install Aerospike Server and Tools$/ {
-            emit_new_block()
-            print ""
-            inserted = 1
-        }
-        { print }
-        ' "${df}" >"${tmp}" && mv "${tmp}" "${df}"
-    fi
-}
-
 # resolve_packages distro edition version tools_version single_arch pkg_type
 # Outputs: x86_link x86_sha arm_link arm_sha pkg_format use_native
 # Sets the variables above in the caller's scope via dynamic scoping.
@@ -365,7 +309,6 @@ function resolve_packages() {
 #   - Patches the version label.
 #   - Removes stale ARG/COPY lines from prior formats.
 #   - Removes vendored-tini COPY block (tini is now fetched at build time).
-#   - Refreshes the OpenSSL/TLS security upgrade RUN block (Ubuntu distros only).
 #   - Re-inlines the install logic as a RUN \ block with fresh URL/SHA values.
 #   - Ensures STOPSIGNAL SIGTERM is present.
 # Relies on caller-scoped: x86_link x86_sha arm_link arm_sha
@@ -382,9 +325,6 @@ function update_dockerfile() {
     cp template/0/entrypoint.sh "${target}/"
     chmod +x "${target}/entrypoint.sh"
     cp template/7/aerospike.template.conf "${target}/"
-
-    # Refresh OpenSSL security upgrade block (Ubuntu distros only; no-op for ubi9/ubi10).
-    _dockerfile_refresh_openssl_block "${df}" "$(basename "${target}")"
 
     # Resolve install script source.
     # use_native is set by resolve_packages (caller-scoped) when no TGZ bundle found.

--- a/lib/update.sh
+++ b/lib/update.sh
@@ -291,7 +291,7 @@ function _dockerfile_refresh_openssl_block() {
             if (/^RUN \\/) { next }
             if (/^[ \t]/)  { next }
             if (/^$/)      { next }
-            emit_new_block(); print ""; state = "done"; print; next
+            emit_new_block(); state = "done"; print; next
         }
         { print }
         END { if (state == "consuming") emit_new_block() }

--- a/releases/7.1/community/ubi9/Dockerfile
+++ b/releases/7.1/community/ubi9/Dockerfile
@@ -5,15 +5,15 @@
 # https://github.com/aerospike/aerospike-server.docker
 #
 
-FROM ubuntu:24.04
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
-LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
+LABEL org.opencontainers.image.title="Aerospike Community Server" \
       org.opencontainers.image.description="Aerospike is a real-time database with predictable performance at petabyte scale with microsecond latency over billions of transactions." \
       org.opencontainers.image.documentation="https://hub.docker.com/_/aerospike" \
-      org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
+      org.opencontainers.image.base.name="registry.access.redhat.com/ubi9/ubi-minimal:9.7" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="7.2.0.20" \
+      org.opencontainers.image.version="7.1.0.25" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -21,48 +21,43 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
 # By selecting "community" you agree to the "COMMUNITY_LICENSE".
 # By selecting "enterprise" you agree to the "ENTERPRISE_LICENSE".
 # By selecting "federal" you agree to the "FEDERAL_LICENSE"
-ARG AEROSPIKE_EDITION="enterprise"
+ARG AEROSPIKE_EDITION="community"
 
-ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+ENV AEROSPIKE_LINUX_BASE="registry.access.redhat.com/ubi9/ubi-minimal:9.7"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
-# hadolint ignore=DL3008
+# hadolint ignore=DL3041
 RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
+  microdnf install -y --setopt=install_weak_deps=0 \
     ca-certificates \
-    procps \
+    procps-ng \
   ; \
-  rm -rf /var/lib/apt/lists/*
-
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
-  ; \
-  rm -rf /var/lib/apt/lists/*
+  microdnf clean all; \
+  rm -rf /var/cache/yum /var/cache/dnf
 
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \
   { \
     # Install curl and resolve arch-specific links.
-    apt-get update; \
-    apt-get install -y --no-install-recommends curl; \
-    ARCH="$(dpkg --print-architecture)"; \
-    if [ "${ARCH}" = "amd64" ]; then \
+    ARCH="$(rpm --eval '%{_arch}')"; \
+    # curl-minimal is preferred on ubi-minimal; fall back to full curl if absent. \
+    if ! command -v curl >/dev/null 2>&1; then \
+        if ! microdnf install -y curl-minimal; then \
+            microdnf install -y curl; \
+        fi; \
+    fi; \
+    if [ "${ARCH}" = "x86_64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='b8f3c0ac22cbedc8ba89055721a88f1d4ef4af35280403ecdf16f0601f20fd9f'; \
-    elif [ "${ARCH}" = "arm64" ]; then \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/7.1.0.25/aerospike-server-community_7.1.0.25_tools-13.0.1_el9_x86_64.tgz'; \
+        pkgSha='0c84f67c23dc114af137369414c4465a1071199be9d5cbc17c32d35204798dcf'; \
+    elif [ "${ARCH}" = "aarch64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
-        pkgSha='ee87770e675a9ba65d666a888937a8134161c9f1aa125933420bc033cd4b31fe'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/7.1.0.25/aerospike-server-community_7.1.0.25_tools-13.0.1_el9_aarch64.tgz'; \
+        pkgSha='8483fe05582d88badd379a71d473e812ab47011ec0bc68dd7db294d8074e07d9'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \
@@ -76,35 +71,43 @@ RUN \
   }; \
   { \
     # Fetch and unpack server package.
+    # findutils: provides find(1) invoked by aerospike-server %post scriptlets. \
+    # shadow-utils: provides groupadd/useradd invoked by %pre/%post scriptlets; \
+    #               retained in the image (needed by many runtime exec workflows). \
+    # tar/gzip: extract the TGZ bundle; removed in cleanup. \
+    microdnf install -y --setopt=install_weak_deps=0 findutils shadow-utils tar gzip; \
     mkdir -p /tmp/aerospike; \
     curl -fL -o /tmp/aerospike/pkg.tgz "${pkgLink}"; \
     echo "${pkgSha} */tmp/aerospike/pkg.tgz" | sha256sum --strict --check -; \
     tar -xzf /tmp/aerospike/pkg.tgz --strip-components=1 -C /tmp/aerospike; \
+    rm /tmp/aerospike/pkg.tgz; \
   }; \
   { \
     # Install Aerospike server and tools.
-    # apt-get install ./deb resolves all dependencies (including libldap for \
-    # enterprise/federal) from the Ubuntu repos automatically — no need to \
-    # pre-install them manually, which risks version conflicts. \
-    apt-get install -y --no-install-recommends \
-        /tmp/aerospike/aerospike-server-*.deb \
-        /tmp/aerospike/aerospike-tools*.deb; \
+    # Install both packages together with rpm -i so the package manager resolves \
+    # dependency ordering and %post scriptlets run in the correct sequence. \
+    # openldap: required by enterprise/federal server at runtime for LDAP auth. \
+    if [ "${AEROSPIKE_EDITION}" = "enterprise" ] || [ "${AEROSPIKE_EDITION}" = "federal" ]; then \
+        microdnf install -y --setopt=install_weak_deps=0 openldap; \
+    fi; \
+    rpm -i --excludedocs \
+        /tmp/aerospike/aerospike-server-*.rpm \
+        /tmp/aerospike/aerospike-tools*.rpm; \
   }; \
   { \
     # Post-install housekeeping.
-    mkdir -p /etc/aerospike /licenses /var/log/aerospike /var/run/aerospike; \
+    mkdir -p /licenses /var/log/aerospike /var/run/aerospike; \
     cp /tmp/aerospike/LICENSE /licenses/; \
     if [ "${AEROSPIKE_EDITION}" = "enterprise" ] || [ "${AEROSPIKE_EDITION}" = "federal" ]; then \
         if [ -f /tmp/aerospike/features.conf ]; then \
+            mkdir -p /etc/aerospike; \
             cp /tmp/aerospike/features.conf /etc/aerospike/features.conf; \
         fi; \
     fi; \
     rm -rf /tmp/aerospike; \
-    # Mark curl as auto-installed so autoremove drops it if nothing else depends on it \
-    # (aerospike-tools may declare a hard Depends on curl; in that case curl stays). \
-    apt-mark auto curl; \
-    apt-get autoremove -y --purge; \
-    rm -rf /var/lib/apt/lists/*; \
+    microdnf remove -y tar gzip; \
+    microdnf clean all; \
+    rm -rf /var/cache/yum /var/cache/dnf; \
   }; \
   echo "done";
 

--- a/releases/7.1/community/ubi9/aerospike.template.conf
+++ b/releases/7.1/community/ubi9/aerospike.template.conf
@@ -1,0 +1,69 @@
+# Aerospike database configuration file
+# This template sets up a single-node, single namespace developer environment.
+#
+# Alternatively, you can pass in your own configuration file.
+# You can see more examples at
+# https://github.com/aerospike/aerospike-server/tree/master/as/etc
+
+# This stanza must come first.
+service {
+	$([ -n "${FEATURE_KEY_FILE}" ] && echo "feature-key-file ${FEATURE_KEY_FILE}")
+	cluster-name docker
+}
+
+logging {
+	$([ -n "${LOGFILE}" ] && echo "# Log file must be an absolute path.")
+	$([ -n "${LOGFILE}" ] && echo "file ${LOGFILE} {")
+	$([ -n "${LOGFILE}" ] && echo "    context any info")
+	$([ -n "${LOGFILE}" ] && echo "}")
+
+	# Send log messages to stdout
+	console {
+		context any info
+	}
+}
+
+network {
+	service {
+		address ${SERVICE_ADDRESS}
+		port ${SERVICE_PORT}
+
+		# Uncomment the following to set the 'access-address' parameter to the
+		# IP address of the Docker host. This will the allow the server to correctly
+		# publish the address which applications and other nodes in the cluster to
+		# use when addressing this node.
+		# access-address <IPADDR>
+	}
+
+	heartbeat {
+		# mesh is used for environments that do not support multicast
+		mode mesh
+		address local
+		port 3002
+		interval 150
+		timeout 10
+	}
+
+	fabric {
+		# Intra-cluster communication port (migrates, replication, etc)
+		# default to same address in 'service'
+		address local
+		port 3001
+	}
+
+}
+
+namespace ${NAMESPACE} {
+	replication-factor 1
+	$( [[ "${DEFAULT_TTL}" != "0" ]] && echo "default-ttl ${DEFAULT_TTL}")
+	$( [[ "${NSUP_PERIOD}" != "0" ]] && echo "nsup-period ${NSUP_PERIOD}")
+
+	storage-engine $([ "${DATA_IN_MEMORY}" = "true" ] && echo "memory" || echo "device") {
+		# For 'storage-engine memory' with 'device' or 'file' backing, we
+		# recommend having multiple devices (eight is recommended). One is used
+		# here for backward compatibility.
+		file /opt/aerospike/data/${NAMESPACE}.dat
+		filesize ${STORAGE_GB}G
+		$(([ -z "${DATA_IN_MEMORY}" ] || [ "${DATA_IN_MEMORY}" = "false" ]) && echo "read-page-cache ${READ_PAGE_CACHE}")
+	}
+}

--- a/releases/7.1/community/ubi9/entrypoint.sh
+++ b/releases/7.1/community/ubi9/entrypoint.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+export FEATURE_KEY_FILE=${FEATURE_KEY_FILE:-"/etc/aerospike/features.conf"}
+export LOGFILE=${LOGFILE:-""}
+export SERVICE_ADDRESS=${SERVICE_ADDRESS:-any}
+export SERVICE_PORT=${SERVICE_PORT:-3000}
+export NAMESPACE=${NAMESPACE:-test}
+export DATA_IN_MEMORY=${DATA_IN_MEMORY:-false}
+export DEFAULT_TTL=${DEFAULT_TTL:-0}
+export MEM_GB=${MEM_GB:-1}
+export NSUP_PERIOD=${NSUP_PERIOD:-120}
+export STORAGE_GB=${STORAGE_GB:-4}
+
+if [ "${DATA_IN_MEMORY}" = "true" ]; then
+    export READ_PAGE_CACHE="false"
+else
+    export READ_PAGE_CACHE="true"
+fi
+
+if asd --version | grep -q "Community"; then
+    FEATURE_KEY_FILE="" # invalid for community edition
+fi
+
+function bash_eval_template() {
+    local template_file=$1
+    local target_file=$2
+
+    echo "" >"${target_file}"
+
+    while IFS= read -r line; do
+        if grep -qE "[$][(]|[{]" <<<"${line}"; then
+            local update
+            update=$(eval echo "\"${line}\"") || exit 1
+            grep -qE "[^[:space:]]*" <<<"${update}" && echo "${update}" >>"${target_file}"
+        else
+            echo "${line}" >>"${target_file}"
+        fi
+    done <"${template_file}"
+
+    # Ignore failure when template is mounted in a read-only filesystem.
+    rm "${template_file}" || true
+}
+
+# Fill out conffile with above values
+if [ -f /etc/aerospike/aerospike.template.conf ]; then
+    conf=/etc/aerospike/aerospike.conf
+    template=/etc/aerospike/aerospike.template.conf
+
+    bash_eval_template "${template}" "${conf}"
+fi
+
+# if command starts with an option, prepend asd
+if [ "${1:0:1}" = '-' ]; then
+    set -- asd "$@"
+fi
+
+# if asd is specified for the command, start it with any given options
+if [ "$1" = 'asd' ]; then
+    NETLINK=${NETLINK:-eth0}
+
+    # We will wait a bit for the network link to be up.
+    NETLINK_UP=0
+    NETLINK_COUNT=0
+
+    echo "link ${NETLINK} state $(cat /sys/class/net/"${NETLINK}"/operstate)"
+
+    while [ ${NETLINK_UP} -eq 0 ] && [ ${NETLINK_COUNT} -lt 20 ]; do
+        if grep -q "up" /sys/class/net/"${NETLINK}"/operstate; then
+            NETLINK_UP=1
+        else
+            sleep 0.1
+            ((++NETLINK_COUNT))
+        fi
+    done
+
+    echo "link ${NETLINK} state $(cat /sys/class/net/"${NETLINK}"/operstate) in ${NETLINK_COUNT}"
+    # asd should always run in the foreground.
+    set -- "$@" --fgdaemon
+fi
+
+exec "$@"

--- a/releases/7.1/community/ubuntu22.04/Dockerfile
+++ b/releases/7.1/community/ubuntu22.04/Dockerfile
@@ -5,15 +5,15 @@
 # https://github.com/aerospike/aerospike-server.docker
 #
 
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
-LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
+LABEL org.opencontainers.image.title="Aerospike Community Server" \
       org.opencontainers.image.description="Aerospike is a real-time database with predictable performance at petabyte scale with microsecond latency over billions of transactions." \
       org.opencontainers.image.documentation="https://hub.docker.com/_/aerospike" \
-      org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
+      org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="7.2.0.20" \
+      org.opencontainers.image.version="7.1.0.25" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -21,9 +21,10 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
 # By selecting "community" you agree to the "COMMUNITY_LICENSE".
 # By selecting "enterprise" you agree to the "ENTERPRISE_LICENSE".
 # By selecting "federal" you agree to the "FEDERAL_LICENSE"
-ARG AEROSPIKE_EDITION="enterprise"
+ARG AEROSPIKE_EDITION="community"
 
-ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+ENV AEROSPIKE_LINUX_BASE="ubuntu:22.04"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -35,13 +36,13 @@ RUN \
   ; \
   rm -rf /var/lib/apt/lists/*
 
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
+# Upgrade openssl/libssl3 and libgnutls30 to patched versions
 RUN \
   apt-get update; \
   apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
+    libgnutls30=3.7.3-4ubuntu1.9 \
+    libssl3=3.0.2-0ubuntu1.25 \
+    openssl=3.0.2-0ubuntu1.25 \
   ; \
   rm -rf /var/lib/apt/lists/*
 
@@ -56,13 +57,13 @@ RUN \
     if [ "${ARCH}" = "amd64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='b8f3c0ac22cbedc8ba89055721a88f1d4ef4af35280403ecdf16f0601f20fd9f'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/7.1.0.25/aerospike-server-community_7.1.0.25_tools-13.0.1_ubuntu22.04_x86_64.tgz'; \
+        pkgSha='15ab6bc159ca05b152c93bfe3b0501a007bfddff41b0d6d95e70ee03b08813fd'; \
     elif [ "${ARCH}" = "arm64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
-        pkgSha='ee87770e675a9ba65d666a888937a8134161c9f1aa125933420bc033cd4b31fe'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/7.1.0.25/aerospike-server-community_7.1.0.25_tools-13.0.1_ubuntu22.04_aarch64.tgz'; \
+        pkgSha='d7c7a1546653db05356da9ec1f11a48c9324fbf9db4515adececc59c44d0eeac'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/7.1/community/ubuntu22.04/Dockerfile
+++ b/releases/7.1/community/ubuntu22.04/Dockerfile
@@ -36,16 +36,6 @@ RUN \
   ; \
   rm -rf /var/lib/apt/lists/*
 
-# Upgrade openssl/libssl3 and libgnutls30 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30=3.7.3-4ubuntu1.9 \
-    libssl3=3.0.2-0ubuntu1.25 \
-    openssl=3.0.2-0ubuntu1.25 \
-  ; \
-  rm -rf /var/lib/apt/lists/*
-
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/7.1/community/ubuntu22.04/aerospike.template.conf
+++ b/releases/7.1/community/ubuntu22.04/aerospike.template.conf
@@ -1,0 +1,69 @@
+# Aerospike database configuration file
+# This template sets up a single-node, single namespace developer environment.
+#
+# Alternatively, you can pass in your own configuration file.
+# You can see more examples at
+# https://github.com/aerospike/aerospike-server/tree/master/as/etc
+
+# This stanza must come first.
+service {
+	$([ -n "${FEATURE_KEY_FILE}" ] && echo "feature-key-file ${FEATURE_KEY_FILE}")
+	cluster-name docker
+}
+
+logging {
+	$([ -n "${LOGFILE}" ] && echo "# Log file must be an absolute path.")
+	$([ -n "${LOGFILE}" ] && echo "file ${LOGFILE} {")
+	$([ -n "${LOGFILE}" ] && echo "    context any info")
+	$([ -n "${LOGFILE}" ] && echo "}")
+
+	# Send log messages to stdout
+	console {
+		context any info
+	}
+}
+
+network {
+	service {
+		address ${SERVICE_ADDRESS}
+		port ${SERVICE_PORT}
+
+		# Uncomment the following to set the 'access-address' parameter to the
+		# IP address of the Docker host. This will the allow the server to correctly
+		# publish the address which applications and other nodes in the cluster to
+		# use when addressing this node.
+		# access-address <IPADDR>
+	}
+
+	heartbeat {
+		# mesh is used for environments that do not support multicast
+		mode mesh
+		address local
+		port 3002
+		interval 150
+		timeout 10
+	}
+
+	fabric {
+		# Intra-cluster communication port (migrates, replication, etc)
+		# default to same address in 'service'
+		address local
+		port 3001
+	}
+
+}
+
+namespace ${NAMESPACE} {
+	replication-factor 1
+	$( [[ "${DEFAULT_TTL}" != "0" ]] && echo "default-ttl ${DEFAULT_TTL}")
+	$( [[ "${NSUP_PERIOD}" != "0" ]] && echo "nsup-period ${NSUP_PERIOD}")
+
+	storage-engine $([ "${DATA_IN_MEMORY}" = "true" ] && echo "memory" || echo "device") {
+		# For 'storage-engine memory' with 'device' or 'file' backing, we
+		# recommend having multiple devices (eight is recommended). One is used
+		# here for backward compatibility.
+		file /opt/aerospike/data/${NAMESPACE}.dat
+		filesize ${STORAGE_GB}G
+		$(([ -z "${DATA_IN_MEMORY}" ] || [ "${DATA_IN_MEMORY}" = "false" ]) && echo "read-page-cache ${READ_PAGE_CACHE}")
+	}
+}

--- a/releases/7.1/community/ubuntu22.04/entrypoint.sh
+++ b/releases/7.1/community/ubuntu22.04/entrypoint.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+export FEATURE_KEY_FILE=${FEATURE_KEY_FILE:-"/etc/aerospike/features.conf"}
+export LOGFILE=${LOGFILE:-""}
+export SERVICE_ADDRESS=${SERVICE_ADDRESS:-any}
+export SERVICE_PORT=${SERVICE_PORT:-3000}
+export NAMESPACE=${NAMESPACE:-test}
+export DATA_IN_MEMORY=${DATA_IN_MEMORY:-false}
+export DEFAULT_TTL=${DEFAULT_TTL:-0}
+export MEM_GB=${MEM_GB:-1}
+export NSUP_PERIOD=${NSUP_PERIOD:-120}
+export STORAGE_GB=${STORAGE_GB:-4}
+
+if [ "${DATA_IN_MEMORY}" = "true" ]; then
+    export READ_PAGE_CACHE="false"
+else
+    export READ_PAGE_CACHE="true"
+fi
+
+if asd --version | grep -q "Community"; then
+    FEATURE_KEY_FILE="" # invalid for community edition
+fi
+
+function bash_eval_template() {
+    local template_file=$1
+    local target_file=$2
+
+    echo "" >"${target_file}"
+
+    while IFS= read -r line; do
+        if grep -qE "[$][(]|[{]" <<<"${line}"; then
+            local update
+            update=$(eval echo "\"${line}\"") || exit 1
+            grep -qE "[^[:space:]]*" <<<"${update}" && echo "${update}" >>"${target_file}"
+        else
+            echo "${line}" >>"${target_file}"
+        fi
+    done <"${template_file}"
+
+    # Ignore failure when template is mounted in a read-only filesystem.
+    rm "${template_file}" || true
+}
+
+# Fill out conffile with above values
+if [ -f /etc/aerospike/aerospike.template.conf ]; then
+    conf=/etc/aerospike/aerospike.conf
+    template=/etc/aerospike/aerospike.template.conf
+
+    bash_eval_template "${template}" "${conf}"
+fi
+
+# if command starts with an option, prepend asd
+if [ "${1:0:1}" = '-' ]; then
+    set -- asd "$@"
+fi
+
+# if asd is specified for the command, start it with any given options
+if [ "$1" = 'asd' ]; then
+    NETLINK=${NETLINK:-eth0}
+
+    # We will wait a bit for the network link to be up.
+    NETLINK_UP=0
+    NETLINK_COUNT=0
+
+    echo "link ${NETLINK} state $(cat /sys/class/net/"${NETLINK}"/operstate)"
+
+    while [ ${NETLINK_UP} -eq 0 ] && [ ${NETLINK_COUNT} -lt 20 ]; do
+        if grep -q "up" /sys/class/net/"${NETLINK}"/operstate; then
+            NETLINK_UP=1
+        else
+            sleep 0.1
+            ((++NETLINK_COUNT))
+        fi
+    done
+
+    echo "link ${NETLINK} state $(cat /sys/class/net/"${NETLINK}"/operstate) in ${NETLINK_COUNT}"
+    # asd should always run in the foreground.
+    set -- "$@" --fgdaemon
+fi
+
+exec "$@"

--- a/releases/7.1/enterprise/ubi9/Dockerfile
+++ b/releases/7.1/enterprise/ubi9/Dockerfile
@@ -5,15 +5,15 @@
 # https://github.com/aerospike/aerospike-server.docker
 #
 
-FROM ubuntu:24.04
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
 LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
       org.opencontainers.image.description="Aerospike is a real-time database with predictable performance at petabyte scale with microsecond latency over billions of transactions." \
       org.opencontainers.image.documentation="https://hub.docker.com/_/aerospike" \
-      org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
+      org.opencontainers.image.base.name="registry.access.redhat.com/ubi9/ubi-minimal:9.7" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="7.2.0.20" \
+      org.opencontainers.image.version="7.1.0.25" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -23,46 +23,41 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
 # By selecting "federal" you agree to the "FEDERAL_LICENSE"
 ARG AEROSPIKE_EDITION="enterprise"
 
-ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+ENV AEROSPIKE_LINUX_BASE="registry.access.redhat.com/ubi9/ubi-minimal:9.7"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
-# hadolint ignore=DL3008
+# hadolint ignore=DL3041
 RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
+  microdnf install -y --setopt=install_weak_deps=0 \
     ca-certificates \
-    procps \
+    procps-ng \
   ; \
-  rm -rf /var/lib/apt/lists/*
-
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
-  ; \
-  rm -rf /var/lib/apt/lists/*
+  microdnf clean all; \
+  rm -rf /var/cache/yum /var/cache/dnf
 
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \
   { \
     # Install curl and resolve arch-specific links.
-    apt-get update; \
-    apt-get install -y --no-install-recommends curl; \
-    ARCH="$(dpkg --print-architecture)"; \
-    if [ "${ARCH}" = "amd64" ]; then \
+    ARCH="$(rpm --eval '%{_arch}')"; \
+    # curl-minimal is preferred on ubi-minimal; fall back to full curl if absent. \
+    if ! command -v curl >/dev/null 2>&1; then \
+        if ! microdnf install -y curl-minimal; then \
+            microdnf install -y curl; \
+        fi; \
+    fi; \
+    if [ "${ARCH}" = "x86_64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='b8f3c0ac22cbedc8ba89055721a88f1d4ef4af35280403ecdf16f0601f20fd9f'; \
-    elif [ "${ARCH}" = "arm64" ]; then \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.1.0.25/aerospike-server-enterprise_7.1.0.25_tools-13.0.1_el9_x86_64.tgz'; \
+        pkgSha='833d7f9ef3f1d601953d7459eaaaf14919a62be7723b6d75c840d777eb9d4755'; \
+    elif [ "${ARCH}" = "aarch64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
-        pkgSha='ee87770e675a9ba65d666a888937a8134161c9f1aa125933420bc033cd4b31fe'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.1.0.25/aerospike-server-enterprise_7.1.0.25_tools-13.0.1_el9_aarch64.tgz'; \
+        pkgSha='226166e36da4f219e35ef8c9a049c158adeb865fd77e88de506d39f57f6e869b'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \
@@ -76,35 +71,43 @@ RUN \
   }; \
   { \
     # Fetch and unpack server package.
+    # findutils: provides find(1) invoked by aerospike-server %post scriptlets. \
+    # shadow-utils: provides groupadd/useradd invoked by %pre/%post scriptlets; \
+    #               retained in the image (needed by many runtime exec workflows). \
+    # tar/gzip: extract the TGZ bundle; removed in cleanup. \
+    microdnf install -y --setopt=install_weak_deps=0 findutils shadow-utils tar gzip; \
     mkdir -p /tmp/aerospike; \
     curl -fL -o /tmp/aerospike/pkg.tgz "${pkgLink}"; \
     echo "${pkgSha} */tmp/aerospike/pkg.tgz" | sha256sum --strict --check -; \
     tar -xzf /tmp/aerospike/pkg.tgz --strip-components=1 -C /tmp/aerospike; \
+    rm /tmp/aerospike/pkg.tgz; \
   }; \
   { \
     # Install Aerospike server and tools.
-    # apt-get install ./deb resolves all dependencies (including libldap for \
-    # enterprise/federal) from the Ubuntu repos automatically — no need to \
-    # pre-install them manually, which risks version conflicts. \
-    apt-get install -y --no-install-recommends \
-        /tmp/aerospike/aerospike-server-*.deb \
-        /tmp/aerospike/aerospike-tools*.deb; \
+    # Install both packages together with rpm -i so the package manager resolves \
+    # dependency ordering and %post scriptlets run in the correct sequence. \
+    # openldap: required by enterprise/federal server at runtime for LDAP auth. \
+    if [ "${AEROSPIKE_EDITION}" = "enterprise" ] || [ "${AEROSPIKE_EDITION}" = "federal" ]; then \
+        microdnf install -y --setopt=install_weak_deps=0 openldap; \
+    fi; \
+    rpm -i --excludedocs \
+        /tmp/aerospike/aerospike-server-*.rpm \
+        /tmp/aerospike/aerospike-tools*.rpm; \
   }; \
   { \
     # Post-install housekeeping.
-    mkdir -p /etc/aerospike /licenses /var/log/aerospike /var/run/aerospike; \
+    mkdir -p /licenses /var/log/aerospike /var/run/aerospike; \
     cp /tmp/aerospike/LICENSE /licenses/; \
     if [ "${AEROSPIKE_EDITION}" = "enterprise" ] || [ "${AEROSPIKE_EDITION}" = "federal" ]; then \
         if [ -f /tmp/aerospike/features.conf ]; then \
+            mkdir -p /etc/aerospike; \
             cp /tmp/aerospike/features.conf /etc/aerospike/features.conf; \
         fi; \
     fi; \
     rm -rf /tmp/aerospike; \
-    # Mark curl as auto-installed so autoremove drops it if nothing else depends on it \
-    # (aerospike-tools may declare a hard Depends on curl; in that case curl stays). \
-    apt-mark auto curl; \
-    apt-get autoremove -y --purge; \
-    rm -rf /var/lib/apt/lists/*; \
+    microdnf remove -y tar gzip; \
+    microdnf clean all; \
+    rm -rf /var/cache/yum /var/cache/dnf; \
   }; \
   echo "done";
 

--- a/releases/7.1/enterprise/ubi9/aerospike.template.conf
+++ b/releases/7.1/enterprise/ubi9/aerospike.template.conf
@@ -1,0 +1,69 @@
+# Aerospike database configuration file
+# This template sets up a single-node, single namespace developer environment.
+#
+# Alternatively, you can pass in your own configuration file.
+# You can see more examples at
+# https://github.com/aerospike/aerospike-server/tree/master/as/etc
+
+# This stanza must come first.
+service {
+	$([ -n "${FEATURE_KEY_FILE}" ] && echo "feature-key-file ${FEATURE_KEY_FILE}")
+	cluster-name docker
+}
+
+logging {
+	$([ -n "${LOGFILE}" ] && echo "# Log file must be an absolute path.")
+	$([ -n "${LOGFILE}" ] && echo "file ${LOGFILE} {")
+	$([ -n "${LOGFILE}" ] && echo "    context any info")
+	$([ -n "${LOGFILE}" ] && echo "}")
+
+	# Send log messages to stdout
+	console {
+		context any info
+	}
+}
+
+network {
+	service {
+		address ${SERVICE_ADDRESS}
+		port ${SERVICE_PORT}
+
+		# Uncomment the following to set the 'access-address' parameter to the
+		# IP address of the Docker host. This will the allow the server to correctly
+		# publish the address which applications and other nodes in the cluster to
+		# use when addressing this node.
+		# access-address <IPADDR>
+	}
+
+	heartbeat {
+		# mesh is used for environments that do not support multicast
+		mode mesh
+		address local
+		port 3002
+		interval 150
+		timeout 10
+	}
+
+	fabric {
+		# Intra-cluster communication port (migrates, replication, etc)
+		# default to same address in 'service'
+		address local
+		port 3001
+	}
+
+}
+
+namespace ${NAMESPACE} {
+	replication-factor 1
+	$( [[ "${DEFAULT_TTL}" != "0" ]] && echo "default-ttl ${DEFAULT_TTL}")
+	$( [[ "${NSUP_PERIOD}" != "0" ]] && echo "nsup-period ${NSUP_PERIOD}")
+
+	storage-engine $([ "${DATA_IN_MEMORY}" = "true" ] && echo "memory" || echo "device") {
+		# For 'storage-engine memory' with 'device' or 'file' backing, we
+		# recommend having multiple devices (eight is recommended). One is used
+		# here for backward compatibility.
+		file /opt/aerospike/data/${NAMESPACE}.dat
+		filesize ${STORAGE_GB}G
+		$(([ -z "${DATA_IN_MEMORY}" ] || [ "${DATA_IN_MEMORY}" = "false" ]) && echo "read-page-cache ${READ_PAGE_CACHE}")
+	}
+}

--- a/releases/7.1/enterprise/ubi9/entrypoint.sh
+++ b/releases/7.1/enterprise/ubi9/entrypoint.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+export FEATURE_KEY_FILE=${FEATURE_KEY_FILE:-"/etc/aerospike/features.conf"}
+export LOGFILE=${LOGFILE:-""}
+export SERVICE_ADDRESS=${SERVICE_ADDRESS:-any}
+export SERVICE_PORT=${SERVICE_PORT:-3000}
+export NAMESPACE=${NAMESPACE:-test}
+export DATA_IN_MEMORY=${DATA_IN_MEMORY:-false}
+export DEFAULT_TTL=${DEFAULT_TTL:-0}
+export MEM_GB=${MEM_GB:-1}
+export NSUP_PERIOD=${NSUP_PERIOD:-120}
+export STORAGE_GB=${STORAGE_GB:-4}
+
+if [ "${DATA_IN_MEMORY}" = "true" ]; then
+    export READ_PAGE_CACHE="false"
+else
+    export READ_PAGE_CACHE="true"
+fi
+
+if asd --version | grep -q "Community"; then
+    FEATURE_KEY_FILE="" # invalid for community edition
+fi
+
+function bash_eval_template() {
+    local template_file=$1
+    local target_file=$2
+
+    echo "" >"${target_file}"
+
+    while IFS= read -r line; do
+        if grep -qE "[$][(]|[{]" <<<"${line}"; then
+            local update
+            update=$(eval echo "\"${line}\"") || exit 1
+            grep -qE "[^[:space:]]*" <<<"${update}" && echo "${update}" >>"${target_file}"
+        else
+            echo "${line}" >>"${target_file}"
+        fi
+    done <"${template_file}"
+
+    # Ignore failure when template is mounted in a read-only filesystem.
+    rm "${template_file}" || true
+}
+
+# Fill out conffile with above values
+if [ -f /etc/aerospike/aerospike.template.conf ]; then
+    conf=/etc/aerospike/aerospike.conf
+    template=/etc/aerospike/aerospike.template.conf
+
+    bash_eval_template "${template}" "${conf}"
+fi
+
+# if command starts with an option, prepend asd
+if [ "${1:0:1}" = '-' ]; then
+    set -- asd "$@"
+fi
+
+# if asd is specified for the command, start it with any given options
+if [ "$1" = 'asd' ]; then
+    NETLINK=${NETLINK:-eth0}
+
+    # We will wait a bit for the network link to be up.
+    NETLINK_UP=0
+    NETLINK_COUNT=0
+
+    echo "link ${NETLINK} state $(cat /sys/class/net/"${NETLINK}"/operstate)"
+
+    while [ ${NETLINK_UP} -eq 0 ] && [ ${NETLINK_COUNT} -lt 20 ]; do
+        if grep -q "up" /sys/class/net/"${NETLINK}"/operstate; then
+            NETLINK_UP=1
+        else
+            sleep 0.1
+            ((++NETLINK_COUNT))
+        fi
+    done
+
+    echo "link ${NETLINK} state $(cat /sys/class/net/"${NETLINK}"/operstate) in ${NETLINK_COUNT}"
+    # asd should always run in the foreground.
+    set -- "$@" --fgdaemon
+fi
+
+exec "$@"

--- a/releases/7.1/enterprise/ubuntu22.04/Dockerfile
+++ b/releases/7.1/enterprise/ubuntu22.04/Dockerfile
@@ -36,16 +36,6 @@ RUN \
   ; \
   rm -rf /var/lib/apt/lists/*
 
-# Upgrade openssl/libssl3 and libgnutls30 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30=3.7.3-4ubuntu1.9 \
-    libssl3=3.0.2-0ubuntu1.25 \
-    openssl=3.0.2-0ubuntu1.25 \
-  ; \
-  rm -rf /var/lib/apt/lists/*
-
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/7.1/enterprise/ubuntu22.04/Dockerfile
+++ b/releases/7.1/enterprise/ubuntu22.04/Dockerfile
@@ -5,15 +5,15 @@
 # https://github.com/aerospike/aerospike-server.docker
 #
 
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
       org.opencontainers.image.description="Aerospike is a real-time database with predictable performance at petabyte scale with microsecond latency over billions of transactions." \
       org.opencontainers.image.documentation="https://hub.docker.com/_/aerospike" \
-      org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
+      org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="7.2.0.20" \
+      org.opencontainers.image.version="7.1.0.25" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -23,7 +23,8 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
 # By selecting "federal" you agree to the "FEDERAL_LICENSE"
 ARG AEROSPIKE_EDITION="enterprise"
 
-ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+ENV AEROSPIKE_LINUX_BASE="ubuntu:22.04"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -35,13 +36,13 @@ RUN \
   ; \
   rm -rf /var/lib/apt/lists/*
 
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
+# Upgrade openssl/libssl3 and libgnutls30 to patched versions
 RUN \
   apt-get update; \
   apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
+    libgnutls30=3.7.3-4ubuntu1.9 \
+    libssl3=3.0.2-0ubuntu1.25 \
+    openssl=3.0.2-0ubuntu1.25 \
   ; \
   rm -rf /var/lib/apt/lists/*
 
@@ -56,13 +57,13 @@ RUN \
     if [ "${ARCH}" = "amd64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='b8f3c0ac22cbedc8ba89055721a88f1d4ef4af35280403ecdf16f0601f20fd9f'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.1.0.25/aerospike-server-enterprise_7.1.0.25_tools-13.0.1_ubuntu22.04_x86_64.tgz'; \
+        pkgSha='638fa961f8c85f29240b77c8a0fc01b18e8469773a395e951b49709f91e4a09c'; \
     elif [ "${ARCH}" = "arm64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
-        pkgSha='ee87770e675a9ba65d666a888937a8134161c9f1aa125933420bc033cd4b31fe'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.1.0.25/aerospike-server-enterprise_7.1.0.25_tools-13.0.1_ubuntu22.04_aarch64.tgz'; \
+        pkgSha='e6364b72b561717e60f0b7aa7f34f1f2f5a1fe73cf7535228e6b34b363e924a0'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/7.1/enterprise/ubuntu22.04/aerospike.template.conf
+++ b/releases/7.1/enterprise/ubuntu22.04/aerospike.template.conf
@@ -1,0 +1,69 @@
+# Aerospike database configuration file
+# This template sets up a single-node, single namespace developer environment.
+#
+# Alternatively, you can pass in your own configuration file.
+# You can see more examples at
+# https://github.com/aerospike/aerospike-server/tree/master/as/etc
+
+# This stanza must come first.
+service {
+	$([ -n "${FEATURE_KEY_FILE}" ] && echo "feature-key-file ${FEATURE_KEY_FILE}")
+	cluster-name docker
+}
+
+logging {
+	$([ -n "${LOGFILE}" ] && echo "# Log file must be an absolute path.")
+	$([ -n "${LOGFILE}" ] && echo "file ${LOGFILE} {")
+	$([ -n "${LOGFILE}" ] && echo "    context any info")
+	$([ -n "${LOGFILE}" ] && echo "}")
+
+	# Send log messages to stdout
+	console {
+		context any info
+	}
+}
+
+network {
+	service {
+		address ${SERVICE_ADDRESS}
+		port ${SERVICE_PORT}
+
+		# Uncomment the following to set the 'access-address' parameter to the
+		# IP address of the Docker host. This will the allow the server to correctly
+		# publish the address which applications and other nodes in the cluster to
+		# use when addressing this node.
+		# access-address <IPADDR>
+	}
+
+	heartbeat {
+		# mesh is used for environments that do not support multicast
+		mode mesh
+		address local
+		port 3002
+		interval 150
+		timeout 10
+	}
+
+	fabric {
+		# Intra-cluster communication port (migrates, replication, etc)
+		# default to same address in 'service'
+		address local
+		port 3001
+	}
+
+}
+
+namespace ${NAMESPACE} {
+	replication-factor 1
+	$( [[ "${DEFAULT_TTL}" != "0" ]] && echo "default-ttl ${DEFAULT_TTL}")
+	$( [[ "${NSUP_PERIOD}" != "0" ]] && echo "nsup-period ${NSUP_PERIOD}")
+
+	storage-engine $([ "${DATA_IN_MEMORY}" = "true" ] && echo "memory" || echo "device") {
+		# For 'storage-engine memory' with 'device' or 'file' backing, we
+		# recommend having multiple devices (eight is recommended). One is used
+		# here for backward compatibility.
+		file /opt/aerospike/data/${NAMESPACE}.dat
+		filesize ${STORAGE_GB}G
+		$(([ -z "${DATA_IN_MEMORY}" ] || [ "${DATA_IN_MEMORY}" = "false" ]) && echo "read-page-cache ${READ_PAGE_CACHE}")
+	}
+}

--- a/releases/7.1/enterprise/ubuntu22.04/entrypoint.sh
+++ b/releases/7.1/enterprise/ubuntu22.04/entrypoint.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+export FEATURE_KEY_FILE=${FEATURE_KEY_FILE:-"/etc/aerospike/features.conf"}
+export LOGFILE=${LOGFILE:-""}
+export SERVICE_ADDRESS=${SERVICE_ADDRESS:-any}
+export SERVICE_PORT=${SERVICE_PORT:-3000}
+export NAMESPACE=${NAMESPACE:-test}
+export DATA_IN_MEMORY=${DATA_IN_MEMORY:-false}
+export DEFAULT_TTL=${DEFAULT_TTL:-0}
+export MEM_GB=${MEM_GB:-1}
+export NSUP_PERIOD=${NSUP_PERIOD:-120}
+export STORAGE_GB=${STORAGE_GB:-4}
+
+if [ "${DATA_IN_MEMORY}" = "true" ]; then
+    export READ_PAGE_CACHE="false"
+else
+    export READ_PAGE_CACHE="true"
+fi
+
+if asd --version | grep -q "Community"; then
+    FEATURE_KEY_FILE="" # invalid for community edition
+fi
+
+function bash_eval_template() {
+    local template_file=$1
+    local target_file=$2
+
+    echo "" >"${target_file}"
+
+    while IFS= read -r line; do
+        if grep -qE "[$][(]|[{]" <<<"${line}"; then
+            local update
+            update=$(eval echo "\"${line}\"") || exit 1
+            grep -qE "[^[:space:]]*" <<<"${update}" && echo "${update}" >>"${target_file}"
+        else
+            echo "${line}" >>"${target_file}"
+        fi
+    done <"${template_file}"
+
+    # Ignore failure when template is mounted in a read-only filesystem.
+    rm "${template_file}" || true
+}
+
+# Fill out conffile with above values
+if [ -f /etc/aerospike/aerospike.template.conf ]; then
+    conf=/etc/aerospike/aerospike.conf
+    template=/etc/aerospike/aerospike.template.conf
+
+    bash_eval_template "${template}" "${conf}"
+fi
+
+# if command starts with an option, prepend asd
+if [ "${1:0:1}" = '-' ]; then
+    set -- asd "$@"
+fi
+
+# if asd is specified for the command, start it with any given options
+if [ "$1" = 'asd' ]; then
+    NETLINK=${NETLINK:-eth0}
+
+    # We will wait a bit for the network link to be up.
+    NETLINK_UP=0
+    NETLINK_COUNT=0
+
+    echo "link ${NETLINK} state $(cat /sys/class/net/"${NETLINK}"/operstate)"
+
+    while [ ${NETLINK_UP} -eq 0 ] && [ ${NETLINK_COUNT} -lt 20 ]; do
+        if grep -q "up" /sys/class/net/"${NETLINK}"/operstate; then
+            NETLINK_UP=1
+        else
+            sleep 0.1
+            ((++NETLINK_COUNT))
+        fi
+    done
+
+    echo "link ${NETLINK} state $(cat /sys/class/net/"${NETLINK}"/operstate) in ${NETLINK_COUNT}"
+    # asd should always run in the foreground.
+    set -- "$@" --fgdaemon
+fi
+
+exec "$@"

--- a/releases/7.1/federal/ubi9/Dockerfile
+++ b/releases/7.1/federal/ubi9/Dockerfile
@@ -5,15 +5,15 @@
 # https://github.com/aerospike/aerospike-server.docker
 #
 
-FROM ubuntu:24.04
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7
 
-LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
+LABEL org.opencontainers.image.title="Aerospike Federal Server" \
       org.opencontainers.image.description="Aerospike is a real-time database with predictable performance at petabyte scale with microsecond latency over billions of transactions." \
       org.opencontainers.image.documentation="https://hub.docker.com/_/aerospike" \
-      org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
+      org.opencontainers.image.base.name="registry.access.redhat.com/ubi9/ubi-minimal:9.7" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="7.2.0.20" \
+      org.opencontainers.image.version="7.1.0.25" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -21,48 +21,43 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
 # By selecting "community" you agree to the "COMMUNITY_LICENSE".
 # By selecting "enterprise" you agree to the "ENTERPRISE_LICENSE".
 # By selecting "federal" you agree to the "FEDERAL_LICENSE"
-ARG AEROSPIKE_EDITION="enterprise"
+ARG AEROSPIKE_EDITION="federal"
 
-ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+ENV AEROSPIKE_LINUX_BASE="registry.access.redhat.com/ubi9/ubi-minimal:9.7"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
-# hadolint ignore=DL3008
+# hadolint ignore=DL3041
 RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
+  microdnf install -y --setopt=install_weak_deps=0 \
     ca-certificates \
-    procps \
+    procps-ng \
   ; \
-  rm -rf /var/lib/apt/lists/*
-
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
-  ; \
-  rm -rf /var/lib/apt/lists/*
+  microdnf clean all; \
+  rm -rf /var/cache/yum /var/cache/dnf
 
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \
   { \
     # Install curl and resolve arch-specific links.
-    apt-get update; \
-    apt-get install -y --no-install-recommends curl; \
-    ARCH="$(dpkg --print-architecture)"; \
-    if [ "${ARCH}" = "amd64" ]; then \
+    ARCH="$(rpm --eval '%{_arch}')"; \
+    # curl-minimal is preferred on ubi-minimal; fall back to full curl if absent. \
+    if ! command -v curl >/dev/null 2>&1; then \
+        if ! microdnf install -y curl-minimal; then \
+            microdnf install -y curl; \
+        fi; \
+    fi; \
+    if [ "${ARCH}" = "x86_64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='b8f3c0ac22cbedc8ba89055721a88f1d4ef4af35280403ecdf16f0601f20fd9f'; \
-    elif [ "${ARCH}" = "arm64" ]; then \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/7.1.0.25/aerospike-server-federal_7.1.0.25_tools-13.0.1_el9_x86_64.tgz'; \
+        pkgSha='426336dfee26cb488f44a6d6784118b63e7294af7b0ce1694a1b48d7c271a9d3'; \
+    elif [ "${ARCH}" = "aarch64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
-        pkgSha='ee87770e675a9ba65d666a888937a8134161c9f1aa125933420bc033cd4b31fe'; \
+        pkgLink=''; \
+        pkgSha=''; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \
@@ -76,35 +71,43 @@ RUN \
   }; \
   { \
     # Fetch and unpack server package.
+    # findutils: provides find(1) invoked by aerospike-server %post scriptlets. \
+    # shadow-utils: provides groupadd/useradd invoked by %pre/%post scriptlets; \
+    #               retained in the image (needed by many runtime exec workflows). \
+    # tar/gzip: extract the TGZ bundle; removed in cleanup. \
+    microdnf install -y --setopt=install_weak_deps=0 findutils shadow-utils tar gzip; \
     mkdir -p /tmp/aerospike; \
     curl -fL -o /tmp/aerospike/pkg.tgz "${pkgLink}"; \
     echo "${pkgSha} */tmp/aerospike/pkg.tgz" | sha256sum --strict --check -; \
     tar -xzf /tmp/aerospike/pkg.tgz --strip-components=1 -C /tmp/aerospike; \
+    rm /tmp/aerospike/pkg.tgz; \
   }; \
   { \
     # Install Aerospike server and tools.
-    # apt-get install ./deb resolves all dependencies (including libldap for \
-    # enterprise/federal) from the Ubuntu repos automatically — no need to \
-    # pre-install them manually, which risks version conflicts. \
-    apt-get install -y --no-install-recommends \
-        /tmp/aerospike/aerospike-server-*.deb \
-        /tmp/aerospike/aerospike-tools*.deb; \
+    # Install both packages together with rpm -i so the package manager resolves \
+    # dependency ordering and %post scriptlets run in the correct sequence. \
+    # openldap: required by enterprise/federal server at runtime for LDAP auth. \
+    if [ "${AEROSPIKE_EDITION}" = "enterprise" ] || [ "${AEROSPIKE_EDITION}" = "federal" ]; then \
+        microdnf install -y --setopt=install_weak_deps=0 openldap; \
+    fi; \
+    rpm -i --excludedocs \
+        /tmp/aerospike/aerospike-server-*.rpm \
+        /tmp/aerospike/aerospike-tools*.rpm; \
   }; \
   { \
     # Post-install housekeeping.
-    mkdir -p /etc/aerospike /licenses /var/log/aerospike /var/run/aerospike; \
+    mkdir -p /licenses /var/log/aerospike /var/run/aerospike; \
     cp /tmp/aerospike/LICENSE /licenses/; \
     if [ "${AEROSPIKE_EDITION}" = "enterprise" ] || [ "${AEROSPIKE_EDITION}" = "federal" ]; then \
         if [ -f /tmp/aerospike/features.conf ]; then \
+            mkdir -p /etc/aerospike; \
             cp /tmp/aerospike/features.conf /etc/aerospike/features.conf; \
         fi; \
     fi; \
     rm -rf /tmp/aerospike; \
-    # Mark curl as auto-installed so autoremove drops it if nothing else depends on it \
-    # (aerospike-tools may declare a hard Depends on curl; in that case curl stays). \
-    apt-mark auto curl; \
-    apt-get autoremove -y --purge; \
-    rm -rf /var/lib/apt/lists/*; \
+    microdnf remove -y tar gzip; \
+    microdnf clean all; \
+    rm -rf /var/cache/yum /var/cache/dnf; \
   }; \
   echo "done";
 

--- a/releases/7.1/federal/ubi9/aerospike.template.conf
+++ b/releases/7.1/federal/ubi9/aerospike.template.conf
@@ -1,0 +1,69 @@
+# Aerospike database configuration file
+# This template sets up a single-node, single namespace developer environment.
+#
+# Alternatively, you can pass in your own configuration file.
+# You can see more examples at
+# https://github.com/aerospike/aerospike-server/tree/master/as/etc
+
+# This stanza must come first.
+service {
+	$([ -n "${FEATURE_KEY_FILE}" ] && echo "feature-key-file ${FEATURE_KEY_FILE}")
+	cluster-name docker
+}
+
+logging {
+	$([ -n "${LOGFILE}" ] && echo "# Log file must be an absolute path.")
+	$([ -n "${LOGFILE}" ] && echo "file ${LOGFILE} {")
+	$([ -n "${LOGFILE}" ] && echo "    context any info")
+	$([ -n "${LOGFILE}" ] && echo "}")
+
+	# Send log messages to stdout
+	console {
+		context any info
+	}
+}
+
+network {
+	service {
+		address ${SERVICE_ADDRESS}
+		port ${SERVICE_PORT}
+
+		# Uncomment the following to set the 'access-address' parameter to the
+		# IP address of the Docker host. This will the allow the server to correctly
+		# publish the address which applications and other nodes in the cluster to
+		# use when addressing this node.
+		# access-address <IPADDR>
+	}
+
+	heartbeat {
+		# mesh is used for environments that do not support multicast
+		mode mesh
+		address local
+		port 3002
+		interval 150
+		timeout 10
+	}
+
+	fabric {
+		# Intra-cluster communication port (migrates, replication, etc)
+		# default to same address in 'service'
+		address local
+		port 3001
+	}
+
+}
+
+namespace ${NAMESPACE} {
+	replication-factor 1
+	$( [[ "${DEFAULT_TTL}" != "0" ]] && echo "default-ttl ${DEFAULT_TTL}")
+	$( [[ "${NSUP_PERIOD}" != "0" ]] && echo "nsup-period ${NSUP_PERIOD}")
+
+	storage-engine $([ "${DATA_IN_MEMORY}" = "true" ] && echo "memory" || echo "device") {
+		# For 'storage-engine memory' with 'device' or 'file' backing, we
+		# recommend having multiple devices (eight is recommended). One is used
+		# here for backward compatibility.
+		file /opt/aerospike/data/${NAMESPACE}.dat
+		filesize ${STORAGE_GB}G
+		$(([ -z "${DATA_IN_MEMORY}" ] || [ "${DATA_IN_MEMORY}" = "false" ]) && echo "read-page-cache ${READ_PAGE_CACHE}")
+	}
+}

--- a/releases/7.1/federal/ubi9/entrypoint.sh
+++ b/releases/7.1/federal/ubi9/entrypoint.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+export FEATURE_KEY_FILE=${FEATURE_KEY_FILE:-"/etc/aerospike/features.conf"}
+export LOGFILE=${LOGFILE:-""}
+export SERVICE_ADDRESS=${SERVICE_ADDRESS:-any}
+export SERVICE_PORT=${SERVICE_PORT:-3000}
+export NAMESPACE=${NAMESPACE:-test}
+export DATA_IN_MEMORY=${DATA_IN_MEMORY:-false}
+export DEFAULT_TTL=${DEFAULT_TTL:-0}
+export MEM_GB=${MEM_GB:-1}
+export NSUP_PERIOD=${NSUP_PERIOD:-120}
+export STORAGE_GB=${STORAGE_GB:-4}
+
+if [ "${DATA_IN_MEMORY}" = "true" ]; then
+    export READ_PAGE_CACHE="false"
+else
+    export READ_PAGE_CACHE="true"
+fi
+
+if asd --version | grep -q "Community"; then
+    FEATURE_KEY_FILE="" # invalid for community edition
+fi
+
+function bash_eval_template() {
+    local template_file=$1
+    local target_file=$2
+
+    echo "" >"${target_file}"
+
+    while IFS= read -r line; do
+        if grep -qE "[$][(]|[{]" <<<"${line}"; then
+            local update
+            update=$(eval echo "\"${line}\"") || exit 1
+            grep -qE "[^[:space:]]*" <<<"${update}" && echo "${update}" >>"${target_file}"
+        else
+            echo "${line}" >>"${target_file}"
+        fi
+    done <"${template_file}"
+
+    # Ignore failure when template is mounted in a read-only filesystem.
+    rm "${template_file}" || true
+}
+
+# Fill out conffile with above values
+if [ -f /etc/aerospike/aerospike.template.conf ]; then
+    conf=/etc/aerospike/aerospike.conf
+    template=/etc/aerospike/aerospike.template.conf
+
+    bash_eval_template "${template}" "${conf}"
+fi
+
+# if command starts with an option, prepend asd
+if [ "${1:0:1}" = '-' ]; then
+    set -- asd "$@"
+fi
+
+# if asd is specified for the command, start it with any given options
+if [ "$1" = 'asd' ]; then
+    NETLINK=${NETLINK:-eth0}
+
+    # We will wait a bit for the network link to be up.
+    NETLINK_UP=0
+    NETLINK_COUNT=0
+
+    echo "link ${NETLINK} state $(cat /sys/class/net/"${NETLINK}"/operstate)"
+
+    while [ ${NETLINK_UP} -eq 0 ] && [ ${NETLINK_COUNT} -lt 20 ]; do
+        if grep -q "up" /sys/class/net/"${NETLINK}"/operstate; then
+            NETLINK_UP=1
+        else
+            sleep 0.1
+            ((++NETLINK_COUNT))
+        fi
+    done
+
+    echo "link ${NETLINK} state $(cat /sys/class/net/"${NETLINK}"/operstate) in ${NETLINK_COUNT}"
+    # asd should always run in the foreground.
+    set -- "$@" --fgdaemon
+fi
+
+exec "$@"

--- a/releases/7.1/federal/ubuntu22.04/Dockerfile
+++ b/releases/7.1/federal/ubuntu22.04/Dockerfile
@@ -5,15 +5,15 @@
 # https://github.com/aerospike/aerospike-server.docker
 #
 
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
-LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
+LABEL org.opencontainers.image.title="Aerospike Federal Server" \
       org.opencontainers.image.description="Aerospike is a real-time database with predictable performance at petabyte scale with microsecond latency over billions of transactions." \
       org.opencontainers.image.documentation="https://hub.docker.com/_/aerospike" \
-      org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
+      org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="7.2.0.20" \
+      org.opencontainers.image.version="7.1.0.25" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -21,9 +21,10 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
 # By selecting "community" you agree to the "COMMUNITY_LICENSE".
 # By selecting "enterprise" you agree to the "ENTERPRISE_LICENSE".
 # By selecting "federal" you agree to the "FEDERAL_LICENSE"
-ARG AEROSPIKE_EDITION="enterprise"
+ARG AEROSPIKE_EDITION="federal"
 
-ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+ENV AEROSPIKE_LINUX_BASE="ubuntu:22.04"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -35,13 +36,13 @@ RUN \
   ; \
   rm -rf /var/lib/apt/lists/*
 
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
+# Upgrade openssl/libssl3 and libgnutls30 to patched versions
 RUN \
   apt-get update; \
   apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
+    libgnutls30=3.7.3-4ubuntu1.9 \
+    libssl3=3.0.2-0ubuntu1.25 \
+    openssl=3.0.2-0ubuntu1.25 \
   ; \
   rm -rf /var/lib/apt/lists/*
 
@@ -56,13 +57,13 @@ RUN \
     if [ "${ARCH}" = "amd64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='b8f3c0ac22cbedc8ba89055721a88f1d4ef4af35280403ecdf16f0601f20fd9f'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/7.1.0.25/aerospike-server-federal_7.1.0.25_tools-13.0.1_ubuntu22.04_x86_64.tgz'; \
+        pkgSha='0e00a08c067a4048ffbe3ac1772dec604bb0dcbf922cb81820941978fc947450'; \
     elif [ "${ARCH}" = "arm64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
-        pkgSha='ee87770e675a9ba65d666a888937a8134161c9f1aa125933420bc033cd4b31fe'; \
+        pkgLink=''; \
+        pkgSha=''; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/7.1/federal/ubuntu22.04/Dockerfile
+++ b/releases/7.1/federal/ubuntu22.04/Dockerfile
@@ -36,16 +36,6 @@ RUN \
   ; \
   rm -rf /var/lib/apt/lists/*
 
-# Upgrade openssl/libssl3 and libgnutls30 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30=3.7.3-4ubuntu1.9 \
-    libssl3=3.0.2-0ubuntu1.25 \
-    openssl=3.0.2-0ubuntu1.25 \
-  ; \
-  rm -rf /var/lib/apt/lists/*
-
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/7.1/federal/ubuntu22.04/aerospike.template.conf
+++ b/releases/7.1/federal/ubuntu22.04/aerospike.template.conf
@@ -1,0 +1,69 @@
+# Aerospike database configuration file
+# This template sets up a single-node, single namespace developer environment.
+#
+# Alternatively, you can pass in your own configuration file.
+# You can see more examples at
+# https://github.com/aerospike/aerospike-server/tree/master/as/etc
+
+# This stanza must come first.
+service {
+	$([ -n "${FEATURE_KEY_FILE}" ] && echo "feature-key-file ${FEATURE_KEY_FILE}")
+	cluster-name docker
+}
+
+logging {
+	$([ -n "${LOGFILE}" ] && echo "# Log file must be an absolute path.")
+	$([ -n "${LOGFILE}" ] && echo "file ${LOGFILE} {")
+	$([ -n "${LOGFILE}" ] && echo "    context any info")
+	$([ -n "${LOGFILE}" ] && echo "}")
+
+	# Send log messages to stdout
+	console {
+		context any info
+	}
+}
+
+network {
+	service {
+		address ${SERVICE_ADDRESS}
+		port ${SERVICE_PORT}
+
+		# Uncomment the following to set the 'access-address' parameter to the
+		# IP address of the Docker host. This will the allow the server to correctly
+		# publish the address which applications and other nodes in the cluster to
+		# use when addressing this node.
+		# access-address <IPADDR>
+	}
+
+	heartbeat {
+		# mesh is used for environments that do not support multicast
+		mode mesh
+		address local
+		port 3002
+		interval 150
+		timeout 10
+	}
+
+	fabric {
+		# Intra-cluster communication port (migrates, replication, etc)
+		# default to same address in 'service'
+		address local
+		port 3001
+	}
+
+}
+
+namespace ${NAMESPACE} {
+	replication-factor 1
+	$( [[ "${DEFAULT_TTL}" != "0" ]] && echo "default-ttl ${DEFAULT_TTL}")
+	$( [[ "${NSUP_PERIOD}" != "0" ]] && echo "nsup-period ${NSUP_PERIOD}")
+
+	storage-engine $([ "${DATA_IN_MEMORY}" = "true" ] && echo "memory" || echo "device") {
+		# For 'storage-engine memory' with 'device' or 'file' backing, we
+		# recommend having multiple devices (eight is recommended). One is used
+		# here for backward compatibility.
+		file /opt/aerospike/data/${NAMESPACE}.dat
+		filesize ${STORAGE_GB}G
+		$(([ -z "${DATA_IN_MEMORY}" ] || [ "${DATA_IN_MEMORY}" = "false" ]) && echo "read-page-cache ${READ_PAGE_CACHE}")
+	}
+}

--- a/releases/7.1/federal/ubuntu22.04/entrypoint.sh
+++ b/releases/7.1/federal/ubuntu22.04/entrypoint.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+export FEATURE_KEY_FILE=${FEATURE_KEY_FILE:-"/etc/aerospike/features.conf"}
+export LOGFILE=${LOGFILE:-""}
+export SERVICE_ADDRESS=${SERVICE_ADDRESS:-any}
+export SERVICE_PORT=${SERVICE_PORT:-3000}
+export NAMESPACE=${NAMESPACE:-test}
+export DATA_IN_MEMORY=${DATA_IN_MEMORY:-false}
+export DEFAULT_TTL=${DEFAULT_TTL:-0}
+export MEM_GB=${MEM_GB:-1}
+export NSUP_PERIOD=${NSUP_PERIOD:-120}
+export STORAGE_GB=${STORAGE_GB:-4}
+
+if [ "${DATA_IN_MEMORY}" = "true" ]; then
+    export READ_PAGE_CACHE="false"
+else
+    export READ_PAGE_CACHE="true"
+fi
+
+if asd --version | grep -q "Community"; then
+    FEATURE_KEY_FILE="" # invalid for community edition
+fi
+
+function bash_eval_template() {
+    local template_file=$1
+    local target_file=$2
+
+    echo "" >"${target_file}"
+
+    while IFS= read -r line; do
+        if grep -qE "[$][(]|[{]" <<<"${line}"; then
+            local update
+            update=$(eval echo "\"${line}\"") || exit 1
+            grep -qE "[^[:space:]]*" <<<"${update}" && echo "${update}" >>"${target_file}"
+        else
+            echo "${line}" >>"${target_file}"
+        fi
+    done <"${template_file}"
+
+    # Ignore failure when template is mounted in a read-only filesystem.
+    rm "${template_file}" || true
+}
+
+# Fill out conffile with above values
+if [ -f /etc/aerospike/aerospike.template.conf ]; then
+    conf=/etc/aerospike/aerospike.conf
+    template=/etc/aerospike/aerospike.template.conf
+
+    bash_eval_template "${template}" "${conf}"
+fi
+
+# if command starts with an option, prepend asd
+if [ "${1:0:1}" = '-' ]; then
+    set -- asd "$@"
+fi
+
+# if asd is specified for the command, start it with any given options
+if [ "$1" = 'asd' ]; then
+    NETLINK=${NETLINK:-eth0}
+
+    # We will wait a bit for the network link to be up.
+    NETLINK_UP=0
+    NETLINK_COUNT=0
+
+    echo "link ${NETLINK} state $(cat /sys/class/net/"${NETLINK}"/operstate)"
+
+    while [ ${NETLINK_UP} -eq 0 ] && [ ${NETLINK_COUNT} -lt 20 ]; do
+        if grep -q "up" /sys/class/net/"${NETLINK}"/operstate; then
+            NETLINK_UP=1
+        else
+            sleep 0.1
+            ((++NETLINK_COUNT))
+        fi
+    done
+
+    echo "link ${NETLINK} state $(cat /sys/class/net/"${NETLINK}"/operstate) in ${NETLINK_COUNT}"
+    # asd should always run in the foreground.
+    set -- "$@" --fgdaemon
+fi
+
+exec "$@"

--- a/releases/7.2/community/ubi9/Dockerfile
+++ b/releases/7.2/community/ubi9/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Community Server" \
       org.opencontainers.image.base.name="registry.access.redhat.com/ubi9/ubi-minimal:9.7" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="7.2.0.20" \
+      org.opencontainers.image.version="7.2.0.19" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -51,13 +51,13 @@ RUN \
     if [ "${ARCH}" = "x86_64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/7.2.0.20/aerospike-server-community_7.2.0.20_tools-13.0.1_el9_x86_64.tgz'; \
-        pkgSha='19403f2712cc29bad5573479cdc8c38e31f162348da7c43ca72d6399eefc19b2'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/7.2.0.19/aerospike-server-community_7.2.0.19_tools-13.0.1_el9_x86_64.tgz'; \
+        pkgSha='fddfaafc729c71142b9bd1f7c2da1bfb3861e5ecb53a3cccd428cf087327fcb2'; \
     elif [ "${ARCH}" = "aarch64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/7.2.0.20/aerospike-server-community_7.2.0.20_tools-13.0.1_el9_aarch64.tgz'; \
-        pkgSha='e362ceff5fd10bb85dd1136f4859ecb5e338291a9f50b55c429106637b83acc1'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/7.2.0.19/aerospike-server-community_7.2.0.19_tools-13.0.1_el9_aarch64.tgz'; \
+        pkgSha='e35d04df872b4348d68f80a7b5798a7fa6017012a9805ca35884cb09468d5426'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/7.2/community/ubuntu24.04/Dockerfile
+++ b/releases/7.2/community/ubuntu24.04/Dockerfile
@@ -44,7 +44,6 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
-
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/7.2/community/ubuntu24.04/Dockerfile
+++ b/releases/7.2/community/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/7.2/community/ubuntu24.04/Dockerfile
+++ b/releases/7.2/community/ubuntu24.04/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Community Server" \
       org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="7.2.0.20" \
+      org.opencontainers.image.version="7.2.0.19" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -24,6 +24,7 @@ LABEL org.opencontainers.image.title="Aerospike Community Server" \
 ARG AEROSPIKE_EDITION="community"
 
 ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -32,16 +33,6 @@ RUN \
   apt-get install -y --no-install-recommends \
     ca-certificates \
     procps \
-  ; \
-  rm -rf /var/lib/apt/lists/*
-
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
 
@@ -56,13 +47,13 @@ RUN \
     if [ "${ARCH}" = "amd64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/7.2.0.20/aerospike-server-community_7.2.0.20_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='25a3e78492a275f09340542a2ae91e2bd3d2142a8b65a763e944f6e075ee55e1'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/7.2.0.19/aerospike-server-community_7.2.0.19_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
+        pkgSha='dc4d29f55629ab91071eba0366d3e7e5081aa7a32a50903100191f0b2eca3683'; \
     elif [ "${ARCH}" = "arm64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/7.2.0.20/aerospike-server-community_7.2.0.20_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
-        pkgSha='c901b0001a915515913ff5a08922555f9c2571f63b079436a5a1a12afcff61c0'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/7.2.0.19/aerospike-server-community_7.2.0.19_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
+        pkgSha='2dfe5016f4f4ad9d8f775e1f33afc4c24a324fedc5819f56866e52dfe2dd4a18'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/7.2/enterprise/ubi9/Dockerfile
+++ b/releases/7.2/enterprise/ubi9/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
       org.opencontainers.image.base.name="registry.access.redhat.com/ubi9/ubi-minimal:9.7" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="7.2.0.20" \
+      org.opencontainers.image.version="7.2.0.19" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -51,13 +51,13 @@ RUN \
     if [ "${ARCH}" = "x86_64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_el9_x86_64.tgz'; \
-        pkgSha='8bed9b0f44dfdd64959523a5540232f8c7ca21ff331faf9b9ce869cdd7c10e72'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.19/aerospike-server-enterprise_7.2.0.19_tools-13.0.1_el9_x86_64.tgz'; \
+        pkgSha='fcb14cf41bd5bf0f03f776c76eacbd6953a97e2a4864110bd9d7575f60d8657f'; \
     elif [ "${ARCH}" = "aarch64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_el9_aarch64.tgz'; \
-        pkgSha='0be93f590fbf9bb4a73922267d333ec782362f1c4a0581d9ba81b1b371553f64'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.19/aerospike-server-enterprise_7.2.0.19_tools-13.0.1_el9_aarch64.tgz'; \
+        pkgSha='1cc49f01b38c5eea5a66d06cfa00af3e641ef65648746373d075c6f3318fc90f'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/7.2/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/7.2/enterprise/ubuntu24.04/Dockerfile
@@ -44,7 +44,6 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
-
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/7.2/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/7.2/enterprise/ubuntu24.04/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
       org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="7.2.0.20" \
+      org.opencontainers.image.version="7.2.0.19" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -24,6 +24,7 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
 ARG AEROSPIKE_EDITION="enterprise"
 
 ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -32,16 +33,6 @@ RUN \
   apt-get install -y --no-install-recommends \
     ca-certificates \
     procps \
-  ; \
-  rm -rf /var/lib/apt/lists/*
-
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
 
@@ -56,13 +47,13 @@ RUN \
     if [ "${ARCH}" = "amd64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='b8f3c0ac22cbedc8ba89055721a88f1d4ef4af35280403ecdf16f0601f20fd9f'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.19/aerospike-server-enterprise_7.2.0.19_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
+        pkgSha='8355b232c679b7ed5ce701892424ceef1dc8f3b0f5db6e19639568d5c8c84998'; \
     elif [ "${ARCH}" = "arm64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.20/aerospike-server-enterprise_7.2.0.20_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
-        pkgSha='ee87770e675a9ba65d666a888937a8134161c9f1aa125933420bc033cd4b31fe'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/7.2.0.19/aerospike-server-enterprise_7.2.0.19_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
+        pkgSha='8138de943eee402893b0e4a232a5b14b67cb3e5b5ba138bd095a077b353425d8'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/7.2/federal/ubi9/Dockerfile
+++ b/releases/7.2/federal/ubi9/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Federal Server" \
       org.opencontainers.image.base.name="registry.access.redhat.com/ubi9/ubi-minimal:9.7" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="7.2.0.20" \
+      org.opencontainers.image.version="7.2.0.19" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -51,8 +51,8 @@ RUN \
     if [ "${ARCH}" = "x86_64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/7.2.0.20/aerospike-server-federal_7.2.0.20_tools-13.0.1_el9_x86_64.tgz'; \
-        pkgSha='a5d5e686f7a63726eef97879cec46a3a0efe556ba2c8d103717053b7752cf59d'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/7.2.0.19/aerospike-server-federal_7.2.0.19_tools-13.0.1_el9_x86_64.tgz'; \
+        pkgSha='8142cb88885ee51e788fa29d7fbbc4c95f852af7043fd8f5c9cabdcd7f0ef0fc'; \
     elif [ "${ARCH}" = "aarch64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \

--- a/releases/7.2/federal/ubuntu24.04/Dockerfile
+++ b/releases/7.2/federal/ubuntu24.04/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Federal Server" \
       org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="7.2.0.20" \
+      org.opencontainers.image.version="7.2.0.19" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -24,6 +24,7 @@ LABEL org.opencontainers.image.title="Aerospike Federal Server" \
 ARG AEROSPIKE_EDITION="federal"
 
 ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -32,16 +33,6 @@ RUN \
   apt-get install -y --no-install-recommends \
     ca-certificates \
     procps \
-  ; \
-  rm -rf /var/lib/apt/lists/*
-
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
 
@@ -56,8 +47,8 @@ RUN \
     if [ "${ARCH}" = "amd64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/7.2.0.20/aerospike-server-federal_7.2.0.20_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='ca22eeef0282151c73555e5936a1df2ab22bc4741c20851ab5b7433fd9595f18'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/7.2.0.19/aerospike-server-federal_7.2.0.19_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
+        pkgSha='37cd2e04e5a0f633bd87f60b677019241b653e37120c1c3fedeaac8f4d9366a9'; \
     elif [ "${ARCH}" = "arm64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \

--- a/releases/7.2/federal/ubuntu24.04/Dockerfile
+++ b/releases/7.2/federal/ubuntu24.04/Dockerfile
@@ -44,7 +44,6 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
-
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/7.2/federal/ubuntu24.04/Dockerfile
+++ b/releases/7.2/federal/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.0/community/ubi9/Dockerfile
+++ b/releases/8.0/community/ubi9/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Community Server" \
       org.opencontainers.image.base.name="registry.access.redhat.com/ubi9/ubi-minimal:9.7" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="8.0.0.18" \
+      org.opencontainers.image.version="8.0.0.17" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -51,13 +51,13 @@ RUN \
     if [ "${ARCH}" = "x86_64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.0.0.18/aerospike-server-community_8.0.0.18_tools-13.0.1_el9_x86_64.tgz'; \
-        pkgSha='fbae4024d527c9b6374c4b0dc7647533449060f399932d42ec786e778dd2ad3b'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.0.0.17/aerospike-server-community_8.0.0.17_tools-13.0.1_el9_x86_64.tgz'; \
+        pkgSha='62112f73aaf9ae493f3204c389522f945badfcb9f033701ae954b8fad901994e'; \
     elif [ "${ARCH}" = "aarch64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.0.0.18/aerospike-server-community_8.0.0.18_tools-13.0.1_el9_aarch64.tgz'; \
-        pkgSha='7c7038991f5f8fdbedb16f11b03920bb26a1bfbd570b891ba32c477da90c070a'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.0.0.17/aerospike-server-community_8.0.0.17_tools-13.0.1_el9_aarch64.tgz'; \
+        pkgSha='017711dc4208fb6ccfac2c5133c75aabaa00b45697e86ecc2ac498bcb811c888'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/8.0/community/ubuntu24.04/Dockerfile
+++ b/releases/8.0/community/ubuntu24.04/Dockerfile
@@ -44,7 +44,6 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
-
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.0/community/ubuntu24.04/Dockerfile
+++ b/releases/8.0/community/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.0/community/ubuntu24.04/Dockerfile
+++ b/releases/8.0/community/ubuntu24.04/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Community Server" \
       org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="8.0.0.18" \
+      org.opencontainers.image.version="8.0.0.17" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -24,6 +24,7 @@ LABEL org.opencontainers.image.title="Aerospike Community Server" \
 ARG AEROSPIKE_EDITION="community"
 
 ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -32,16 +33,6 @@ RUN \
   apt-get install -y --no-install-recommends \
     ca-certificates \
     procps \
-  ; \
-  rm -rf /var/lib/apt/lists/*
-
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
 
@@ -56,13 +47,13 @@ RUN \
     if [ "${ARCH}" = "amd64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.0.0.18/aerospike-server-community_8.0.0.18_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='576d4ac168d9ee74ab92f98b9cacd0a4c76a2747c7935089bf3d5b76a11ff8c3'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.0.0.17/aerospike-server-community_8.0.0.17_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
+        pkgSha='80c0bec3d81e1580719015106c5aeef32e2ad0e39dd1e837da65d28a5a0891fd'; \
     elif [ "${ARCH}" = "arm64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.0.0.18/aerospike-server-community_8.0.0.18_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
-        pkgSha='472f9d6675668721f50cb51b434c95dacf8fb7f6a5bb7b4608e453d0acb2a6df'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.0.0.17/aerospike-server-community_8.0.0.17_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
+        pkgSha='6cb88f5a922d5fda93397bd203d674cc3b8837b533eac9cd076d652df73a0ad8'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/8.0/enterprise/ubi9/Dockerfile
+++ b/releases/8.0/enterprise/ubi9/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
       org.opencontainers.image.base.name="registry.access.redhat.com/ubi9/ubi-minimal:9.7" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="8.0.0.18" \
+      org.opencontainers.image.version="8.0.0.17" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -51,13 +51,13 @@ RUN \
     if [ "${ARCH}" = "x86_64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.0.0.18/aerospike-server-enterprise_8.0.0.18_tools-13.0.1_el9_x86_64.tgz'; \
-        pkgSha='3afae110ebe02a1f9604645a1bdf4a102e3a1e13be847a8f863bc864b16b1a2f'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.0.0.17/aerospike-server-enterprise_8.0.0.17_tools-13.0.1_el9_x86_64.tgz'; \
+        pkgSha='89461c3cefeb152b564ffee93b38252f8312ac5c154278283a24b6e8166a4a4b'; \
     elif [ "${ARCH}" = "aarch64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.0.0.18/aerospike-server-enterprise_8.0.0.18_tools-13.0.1_el9_aarch64.tgz'; \
-        pkgSha='00d0b975f95a44f067a16549fb6cb43c8fddc5c8c6f5297b8aa1d69545b5b659'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.0.0.17/aerospike-server-enterprise_8.0.0.17_tools-13.0.1_el9_aarch64.tgz'; \
+        pkgSha='20fa081701572023b6de94a758ffd6f5500811d7e01e5ba802751fe2539d521f'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/8.0/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/8.0/enterprise/ubuntu24.04/Dockerfile
@@ -44,7 +44,6 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
-
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.0/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/8.0/enterprise/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.0/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/8.0/enterprise/ubuntu24.04/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
       org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="8.0.0.18" \
+      org.opencontainers.image.version="8.0.0.17" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -24,6 +24,7 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
 ARG AEROSPIKE_EDITION="enterprise"
 
 ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -32,16 +33,6 @@ RUN \
   apt-get install -y --no-install-recommends \
     ca-certificates \
     procps \
-  ; \
-  rm -rf /var/lib/apt/lists/*
-
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
 
@@ -56,13 +47,13 @@ RUN \
     if [ "${ARCH}" = "amd64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.0.0.18/aerospike-server-enterprise_8.0.0.18_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='318fcdc34193e4aa38d29729784f834360f9366b3c2eecb43b9e35bee135d6c5'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.0.0.17/aerospike-server-enterprise_8.0.0.17_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
+        pkgSha='351646bdcb9ab9ef3e9f161b2ceac3361cd0bd44653b8f91161f49a8d9412db1'; \
     elif [ "${ARCH}" = "arm64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.0.0.18/aerospike-server-enterprise_8.0.0.18_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
-        pkgSha='0855528126a404a4a2fccb6e2bf7a71d70aafbec69297d999d16c1d41938a924'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.0.0.17/aerospike-server-enterprise_8.0.0.17_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
+        pkgSha='9cbe44b7f05efea056f761bb597be68500841dd0c0d056a80281f59d4302464f'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/8.0/federal/ubi9/Dockerfile
+++ b/releases/8.0/federal/ubi9/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Federal Server" \
       org.opencontainers.image.base.name="registry.access.redhat.com/ubi9/ubi-minimal:9.7" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="8.0.0.18" \
+      org.opencontainers.image.version="8.0.0.17" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -51,8 +51,8 @@ RUN \
     if [ "${ARCH}" = "x86_64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/8.0.0.18/aerospike-server-federal_8.0.0.18_tools-13.0.1_el9_x86_64.tgz'; \
-        pkgSha='439b826c5f5273df4da7f8660d78bc144102c40635c5eba975336fe205703593'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/8.0.0.17/aerospike-server-federal_8.0.0.17_tools-13.0.1_el9_x86_64.tgz'; \
+        pkgSha='0cde88bb69d42db0b6342f8d3a46459ce81099437776af1870af3c97f3e99709'; \
     elif [ "${ARCH}" = "aarch64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \

--- a/releases/8.0/federal/ubuntu24.04/Dockerfile
+++ b/releases/8.0/federal/ubuntu24.04/Dockerfile
@@ -44,7 +44,6 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
-
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.0/federal/ubuntu24.04/Dockerfile
+++ b/releases/8.0/federal/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.0/federal/ubuntu24.04/Dockerfile
+++ b/releases/8.0/federal/ubuntu24.04/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Federal Server" \
       org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="8.0.0.18" \
+      org.opencontainers.image.version="8.0.0.17" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -24,6 +24,7 @@ LABEL org.opencontainers.image.title="Aerospike Federal Server" \
 ARG AEROSPIKE_EDITION="federal"
 
 ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -32,16 +33,6 @@ RUN \
   apt-get install -y --no-install-recommends \
     ca-certificates \
     procps \
-  ; \
-  rm -rf /var/lib/apt/lists/*
-
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
 
@@ -56,8 +47,8 @@ RUN \
     if [ "${ARCH}" = "amd64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/8.0.0.18/aerospike-server-federal_8.0.0.18_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='c56ba60a2d0aedff3077e8a57d3f9d700f8264ff365e61061741b287cf4519f6'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/8.0.0.17/aerospike-server-federal_8.0.0.17_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
+        pkgSha='f23abff35ba67d0f62e95df2ca72d6fc809dd581a493bdf95ebad31228ecfa34'; \
     elif [ "${ARCH}" = "arm64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \

--- a/releases/8.1/community/ubi10/Dockerfile
+++ b/releases/8.1/community/ubi10/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Community Server" \
       org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi-minimal:10.0" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="8.1.2.3" \
+      org.opencontainers.image.version="8.1.2.2" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -51,13 +51,13 @@ RUN \
     if [ "${ARCH}" = "x86_64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.1.2.3/aerospike-server-community_8.1.2.3_tools-13.0.1_el10_x86_64.tgz'; \
-        pkgSha='ef1bca33fc88a1981575a8bba64d9dcc1a5597edad726284f6c3619b623d5ef1'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.1.2.2/aerospike-server-community_8.1.2.2_tools-13.0.1_el10_x86_64.tgz'; \
+        pkgSha='f8771651679b704f65a2fa930736adb7dd224f24954445b5e881cbb7724d707b'; \
     elif [ "${ARCH}" = "aarch64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.1.2.3/aerospike-server-community_8.1.2.3_tools-13.0.1_el10_aarch64.tgz'; \
-        pkgSha='1bc2e0f122afa48a7f451397797e7dfafc4f3ceeed5bbf02ef21d3296d60b3ff'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.1.2.2/aerospike-server-community_8.1.2.2_tools-13.0.1_el10_aarch64.tgz'; \
+        pkgSha='6585a307a8a8444dd898e81901f21a3860a3db44661ed04fe54ddad03a965122'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/8.1/community/ubuntu24.04/Dockerfile
+++ b/releases/8.1/community/ubuntu24.04/Dockerfile
@@ -44,7 +44,6 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
-
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.1/community/ubuntu24.04/Dockerfile
+++ b/releases/8.1/community/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.1/community/ubuntu24.04/Dockerfile
+++ b/releases/8.1/community/ubuntu24.04/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Community Server" \
       org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="8.1.2.3" \
+      org.opencontainers.image.version="8.1.2.2" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -24,6 +24,7 @@ LABEL org.opencontainers.image.title="Aerospike Community Server" \
 ARG AEROSPIKE_EDITION="community"
 
 ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -32,16 +33,6 @@ RUN \
   apt-get install -y --no-install-recommends \
     ca-certificates \
     procps \
-  ; \
-  rm -rf /var/lib/apt/lists/*
-
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
 
@@ -56,13 +47,13 @@ RUN \
     if [ "${ARCH}" = "amd64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.1.2.3/aerospike-server-community_8.1.2.3_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='676cbf17e11f6f3919a27a693fc7d8129734ab4878c0b91990bd6d437eafa8dd'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.1.2.2/aerospike-server-community_8.1.2.2_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
+        pkgSha='3f3e8d1e3727da60323e072c14308a756335a486d0fb951b8421d6445c891eb1'; \
     elif [ "${ARCH}" = "arm64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.1.2.3/aerospike-server-community_8.1.2.3_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
-        pkgSha='19b380d17586f23b736e346a3855796a155a3e9f3bb242c5e8ec6622f6dc6744'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-community/8.1.2.2/aerospike-server-community_8.1.2.2_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
+        pkgSha='b216371bd2a0a4ac1c65c6c5887d6f2bc051e83b09a0f8617a0f94fe59c78017'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/8.1/enterprise/ubi10/Dockerfile
+++ b/releases/8.1/enterprise/ubi10/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
       org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi-minimal:10.0" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="8.1.2.3" \
+      org.opencontainers.image.version="8.1.2.2" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -51,13 +51,13 @@ RUN \
     if [ "${ARCH}" = "x86_64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.1.2.3/aerospike-server-enterprise_8.1.2.3_tools-13.0.1_el10_x86_64.tgz'; \
-        pkgSha='edf94f3d38efd5a88a5837abd92decea1d0d7ac2960599dec543f6e66e550e65'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.1.2.2/aerospike-server-enterprise_8.1.2.2_tools-13.0.1_el10_x86_64.tgz'; \
+        pkgSha='2aa7f6e0cece6c9a6a596bcbd66389d7f6260554c6c674b6d6b36a69b7f37524'; \
     elif [ "${ARCH}" = "aarch64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.1.2.3/aerospike-server-enterprise_8.1.2.3_tools-13.0.1_el10_aarch64.tgz'; \
-        pkgSha='0005bc7ac890ec39797a3642e6b404e42674d890adf9d9bdbe2d21c74b56d2dd'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.1.2.2/aerospike-server-enterprise_8.1.2.2_tools-13.0.1_el10_aarch64.tgz'; \
+        pkgSha='18a8a5c1b1a5acbac46a876d8eb81c0ac3ccce90cb1f92db839124475cc9b28a'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/8.1/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/8.1/enterprise/ubuntu24.04/Dockerfile
@@ -44,7 +44,6 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
-
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.1/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/8.1/enterprise/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.1/enterprise/ubuntu24.04/Dockerfile
+++ b/releases/8.1/enterprise/ubuntu24.04/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
       org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="8.1.2.3" \
+      org.opencontainers.image.version="8.1.2.2" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -24,6 +24,7 @@ LABEL org.opencontainers.image.title="Aerospike Enterprise Server" \
 ARG AEROSPIKE_EDITION="enterprise"
 
 ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -32,16 +33,6 @@ RUN \
   apt-get install -y --no-install-recommends \
     ca-certificates \
     procps \
-  ; \
-  rm -rf /var/lib/apt/lists/*
-
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
 
@@ -56,13 +47,13 @@ RUN \
     if [ "${ARCH}" = "amd64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.1.2.3/aerospike-server-enterprise_8.1.2.3_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='e065f91d1d1acdc807f347b888b85ee9c6695f64b772b8455374fa492c8f59cd'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.1.2.2/aerospike-server-enterprise_8.1.2.2_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
+        pkgSha='a04ebcb7546ea4bc7e72b71054da58c0fb3aa150a63f3662c655314436ced1a7'; \
     elif [ "${ARCH}" = "arm64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.1.2.3/aerospike-server-enterprise_8.1.2.3_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
-        pkgSha='80d193462128a70d43a37d716ca57f896ce3b6cf6dc95daec9a079f8338c3869'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-enterprise/8.1.2.2/aerospike-server-enterprise_8.1.2.2_tools-13.0.1_ubuntu24.04_aarch64.tgz'; \
+        pkgSha='6ed0285d6c81c81689ca408b94c1704317510ced9c01d56b9057fae48ff53fcb'; \
     else \
         echo >&2 "error: unsupported architecture '${ARCH}'"; \
         exit 1; \

--- a/releases/8.1/federal/ubi10/Dockerfile
+++ b/releases/8.1/federal/ubi10/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Federal Server" \
       org.opencontainers.image.base.name="registry.access.redhat.com/ubi10/ubi-minimal:10.0" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="8.1.2.3" \
+      org.opencontainers.image.version="8.1.2.2" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -51,8 +51,8 @@ RUN \
     if [ "${ARCH}" = "x86_64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/8.1.2.3/aerospike-server-federal_8.1.2.3_tools-13.0.1_el10_x86_64.tgz'; \
-        pkgSha='67fc2a4148ac34bf7cbb423d2261fe0ecf4b4b7f1b512f678dfbe7530a7882d1'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/8.1.2.2/aerospike-server-federal_8.1.2.2_tools-13.0.1_el10_x86_64.tgz'; \
+        pkgSha='927f00679e4aa8f4982c5878bb87ca3be59b6ab9a0d46874d5ddd18d6edd16d5'; \
     elif [ "${ARCH}" = "aarch64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \

--- a/releases/8.1/federal/ubuntu24.04/Dockerfile
+++ b/releases/8.1/federal/ubuntu24.04/Dockerfile
@@ -44,7 +44,6 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
-
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.1/federal/ubuntu24.04/Dockerfile
+++ b/releases/8.1/federal/ubuntu24.04/Dockerfile
@@ -44,6 +44,7 @@ RUN \
     openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
+
 # Install Aerospike Server and Tools
 # hadolint ignore=DL3003,DL3008,DL3041,SC2015
 RUN \

--- a/releases/8.1/federal/ubuntu24.04/Dockerfile
+++ b/releases/8.1/federal/ubuntu24.04/Dockerfile
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.title="Aerospike Federal Server" \
       org.opencontainers.image.base.name="docker.io/library/ubuntu:24.04" \
       org.opencontainers.image.source="https://github.com/aerospike/aerospike-server.docker" \
       org.opencontainers.image.vendor="Aerospike" \
-      org.opencontainers.image.version="8.1.2.3" \
+      org.opencontainers.image.version="8.1.2.2" \
       org.opencontainers.image.url="https://github.com/aerospike/aerospike-server.docker"
 
 # AEROSPIKE_EDITION - required - must be "community", "enterprise", or
@@ -24,6 +24,7 @@ LABEL org.opencontainers.image.title="Aerospike Federal Server" \
 ARG AEROSPIKE_EDITION="federal"
 
 ENV AEROSPIKE_LINUX_BASE="ubuntu:24.04"
+
 SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
@@ -32,16 +33,6 @@ RUN \
   apt-get install -y --no-install-recommends \
     ca-certificates \
     procps \
-  ; \
-  rm -rf /var/lib/apt/lists/*
-
-# Upgrade openssl/libssl3t64 and libgnutls30t64 to patched versions
-RUN \
-  apt-get update; \
-  apt-get install -y --no-install-recommends \
-    libgnutls30t64=3.8.3-1.1ubuntu3.6 \
-    libssl3t64=3.0.13-0ubuntu3.11 \
-    openssl=3.0.13-0ubuntu3.11 \
   ; \
   rm -rf /var/lib/apt/lists/*
 
@@ -56,8 +47,8 @@ RUN \
     if [ "${ARCH}" = "amd64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static'; \
         tiniSha='d1f6826dd70cdd88dde3d5a20d8ed248883a3bc2caba3071c8a3a9b0e0de5940'; \
-        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/8.1.2.3/aerospike-server-federal_8.1.2.3_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
-        pkgSha='257a38b144e1d3651b9c52d8f224a6bf6482174b87c5f1817e793ebc7bd8e225'; \
+        pkgLink='https://download.aerospike.com/artifacts/aerospike-server-federal/8.1.2.2/aerospike-server-federal_8.1.2.2_tools-13.0.1_ubuntu24.04_x86_64.tgz'; \
+        pkgSha='06b8f766493956f5e3622ab93a9f0d273299506ee7ed1441b9ca7a02218d83d3'; \
     elif [ "${ARCH}" = "arm64" ]; then \
         tiniUrl='https://github.com/aerospike/tini/releases/download/1.0.1/as-tini-static-arm64'; \
         tiniSha='1c398e5283af2f33888b7d8ac5b01ac89f777ea27c85d25866a40d1e64d0341b'; \


### PR DESCRIPTION
## Summary

- Reverts commits merged after `bbf7b1fefe8c44c46d9a9a35e44dd126a1c2e18e` (Hotfixes 7.1.0.25, 7.2.0.19, 8.0.0.17, 8.1.2.2 — #96), bringing the branch back to that state.
- Reverted commits (newest → oldest):
  - `9e55e18` — Fix missing blank line between openssl upgrade block and install anchor (#99)
  - `f0230a1` — CVE-2026-45447 (#98)
  - `0d689ca` — Hotfixes 7.2.0.20, 8.0.0.18, 8.1.2.3 (#97)

## Test plan

- [ ] Verify the resulting tree matches the state at `bbf7b1fefe8c44c46d9a9a35e44dd126a1c2e18e`
- [ ] Confirm Docker image builds succeed for the restored release directories