### PR TITLE
SERVER-1389: document and test server argument passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 	-	[List of template variables](#list-of-template-variables)
 	-	[Preconfigured namespace](#preconfigured-namespace)
 -	[Advanced Configuration](#advanced-configuration)
+	-	[Passing server command-line arguments](#passing-server-command-line-arguments)
 	-	[Persistent data directory](#persistent-data-directory)
 	-	[Block storage](#block-storage)
 	-	[Persistent Lua cache](#persistent-lua-cache)
@@ -236,6 +237,29 @@ For example:
 ```sh
 docker run -d -v /opt/aerospike/etc/:/opt/aerospike/etc/ --name aerospike -p 3000-3002:3000-3002 container.aerospike.com/aerospike/aerospike-server-enterprise --config-file /opt/aerospike/etc/aerospike.conf
 ```
+
+### Passing server command-line arguments
+
+The image's default command is `asd`, so any arguments you supply after the image name replace it. When the first argument begins with `-`, the entrypoint prepends `asd` and appends `--fgdaemon` so the server runs in the foreground — pass only the flags you want. A first argument that does not begin with `-` is run as the container command instead, so `bash` gives you a shell.
+
+This is a supported interface: container orchestrators can set server flags without replacing the image's entrypoint.
+
+For example, to enable verbose logging before the configuration file is parsed:
+
+```sh
+docker run -d --name aerospike -p 3000-3002:3000-3002 container.aerospike.com/aerospike/aerospike-server-enterprise --early-verbose
+```
+
+Under Kubernetes, set `args` on the server container and leave `command` unset so the entrypoint still runs:
+
+```yaml
+args:
+  - --early-verbose
+```
+
+Available flags and their arguments vary by server version. Run `asd --help` in the image you are targeting to see the options that version supports.
+
+Environment variables are not translated into command-line arguments. The variables in [List of template variables](#list-of-template-variables) are substituted into the default configuration template; they are not passed to `asd`.
 
 ### Persistent data directory
 

--- a/README.md
+++ b/README.md
@@ -242,9 +242,11 @@ docker run -d -v /opt/aerospike/etc/:/opt/aerospike/etc/ --name aerospike -p 300
 
 The image's default command is `asd`, so any arguments you supply after the image name replace it. The entrypoint then dispatches on the first argument:
 
--	Begins with `-`: the entrypoint prepends `asd` and appends `--fgdaemon` so the server runs in the foreground. Pass only the flags you want.
--	Is `asd`: the entrypoint waits for the network link and appends `--fgdaemon`, so `asd --early-verbose` behaves the same as `--early-verbose` alone.
+-	Begins with `-`: the entrypoint prepends `asd`. Pass only the flags you want.
+-	Is `asd`: used as given.
 -	Anything else: exec'd as the container command, so `bash` gives you a shell.
+
+Whenever the command resolves to `asd` (whether you passed flags or named `asd` explicitly), the entrypoint waits for the network link and appends `--fgdaemon` so the server runs in the foreground. So `asd --early-verbose` and `--early-verbose` alone are equivalent.
 
 This is a supported interface: container orchestrators can set server flags without replacing the image's entrypoint.
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,11 @@ docker run -d -v /opt/aerospike/etc/:/opt/aerospike/etc/ --name aerospike -p 300
 
 ### Passing server command-line arguments
 
-The image's default command is `asd`, so any arguments you supply after the image name replace it. When the first argument begins with `-`, the entrypoint prepends `asd` and appends `--fgdaemon` so the server runs in the foreground — pass only the flags you want. A first argument that does not begin with `-` is run as the container command instead, so `bash` gives you a shell.
+The image's default command is `asd`, so any arguments you supply after the image name replace it. The entrypoint then dispatches on the first argument:
+
+-	Begins with `-`: the entrypoint prepends `asd` and appends `--fgdaemon` so the server runs in the foreground. Pass only the flags you want.
+-	Is `asd`: the entrypoint waits for the network link and appends `--fgdaemon`, so `asd --early-verbose` behaves the same as `--early-verbose` alone.
+-	Anything else: exec'd as the container command, so `bash` gives you a shell.
 
 This is a supported interface: container orchestrators can set server flags without replacing the image's entrypoint.
 

--- a/releases/7.1/community/ubi9/entrypoint.sh
+++ b/releases/7.1/community/ubi9/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/7.1/community/ubuntu22.04/entrypoint.sh
+++ b/releases/7.1/community/ubuntu22.04/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/7.1/enterprise/ubi9/entrypoint.sh
+++ b/releases/7.1/enterprise/ubi9/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/7.1/enterprise/ubuntu22.04/entrypoint.sh
+++ b/releases/7.1/enterprise/ubuntu22.04/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/7.1/federal/ubi9/entrypoint.sh
+++ b/releases/7.1/federal/ubi9/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/7.1/federal/ubuntu22.04/entrypoint.sh
+++ b/releases/7.1/federal/ubuntu22.04/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/7.2/community/ubi9/entrypoint.sh
+++ b/releases/7.2/community/ubi9/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/7.2/community/ubuntu24.04/entrypoint.sh
+++ b/releases/7.2/community/ubuntu24.04/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/7.2/enterprise/ubi9/entrypoint.sh
+++ b/releases/7.2/enterprise/ubi9/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/7.2/enterprise/ubuntu24.04/entrypoint.sh
+++ b/releases/7.2/enterprise/ubuntu24.04/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/7.2/federal/ubi9/entrypoint.sh
+++ b/releases/7.2/federal/ubi9/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/7.2/federal/ubuntu24.04/entrypoint.sh
+++ b/releases/7.2/federal/ubuntu24.04/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/8.0/community/ubi9/entrypoint.sh
+++ b/releases/8.0/community/ubi9/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/8.0/community/ubuntu24.04/entrypoint.sh
+++ b/releases/8.0/community/ubuntu24.04/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/8.0/enterprise/ubi9/entrypoint.sh
+++ b/releases/8.0/enterprise/ubi9/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/8.0/enterprise/ubuntu24.04/entrypoint.sh
+++ b/releases/8.0/enterprise/ubuntu24.04/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/8.0/federal/ubi9/entrypoint.sh
+++ b/releases/8.0/federal/ubi9/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/8.0/federal/ubuntu24.04/entrypoint.sh
+++ b/releases/8.0/federal/ubuntu24.04/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/8.1/community/ubi10/entrypoint.sh
+++ b/releases/8.1/community/ubi10/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/8.1/community/ubuntu24.04/entrypoint.sh
+++ b/releases/8.1/community/ubuntu24.04/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/8.1/enterprise/ubi10/entrypoint.sh
+++ b/releases/8.1/enterprise/ubi10/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/8.1/enterprise/ubuntu24.04/entrypoint.sh
+++ b/releases/8.1/enterprise/ubuntu24.04/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/8.1/federal/ubi10/entrypoint.sh
+++ b/releases/8.1/federal/ubi10/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/releases/8.1/federal/ubuntu24.04/entrypoint.sh
+++ b/releases/8.1/federal/ubuntu24.04/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/template/0/entrypoint.sh
+++ b/template/0/entrypoint.sh
@@ -51,6 +51,10 @@ if [ -f /etc/aerospike/aerospike.template.conf ]; then
     bash_eval_template "${template}" "${conf}"
 fi
 
+# Forwarding server arguments to asd is a documented interface (see README,
+# "Passing server command-line arguments"). Container orchestrators rely on it to
+# set server flags without replacing the entrypoint; preserve it.
+
 # if command starts with an option, prepend asd
 if [ "${1:0:1}" = '-' ]; then
     set -- asd "$@"

--- a/test.sh
+++ b/test.sh
@@ -358,6 +358,9 @@ function check_arg_passthrough() {
         exit 1
     fi
 
+    # Single quotes are deliberate: this runs under "bash -c" inside the container,
+    # so $p and the command substitution must reach it unexpanded.
+    # shellcheck disable=SC2016
     local find_asd='for p in /proc/[0-9]*; do [ "$(cat "$p/comm" 2>/dev/null)" = asd ] && { tr "\0" " " <"$p/cmdline"; exit 0; }; done; exit 1'
 
     local cmdline=""

--- a/test.sh
+++ b/test.sh
@@ -53,7 +53,9 @@ TESTS PERFORMED:
     5. Version matches expected (if detectable)
     6. Edition matches expected (if -e specified)
     7. Default namespace 'test' exists
-    8. Snyk container scan (optional, with -s/--snyk)
+    8. Server arguments are forwarded to asd
+    9. Non-option command is exec'd as given
+    10. Snyk container scan (optional, with -s/--snyk)
 
 EXAMPLES:
     # Test a specific image (from any registry)
@@ -340,9 +342,15 @@ function check_container() {
 # PID 1 is tini, so asd is located by scanning /proc (procps may not be in image).
 function check_arg_passthrough() {
     local probe="${CONTAINER}-args"
-    # Benign flag: this is already the default path the entrypoint writes the conf to.
-    local probe_arg="--config-file"
-    local probe_val="/etc/aerospike/aerospike.conf"
+    # The probe flag must be one the entrypoint could never emit on its own,
+    # otherwise the test proves nothing. --config-file is unusable here: its value
+    # would be both asd's default and the exact path the entrypoint writes the conf
+    # to, so an entrypoint that dropped "$@" and hardcoded that flag would produce a
+    # byte-identical argv and pass. --early-verbose is inert (verbose logging before
+    # config parse), is never synthesized by the entrypoint, and exists in every
+    # shipped lineage.
+    local probe_arg="--early-verbose"
+    local expect="asd ${probe_arg} --fgdaemon"
 
     log_info "Verifying server argument passthrough..."
 
@@ -351,9 +359,9 @@ function check_arg_passthrough() {
     local run_opts=(-td --name "${probe}" -e "DEFAULT_TTL=30d")
     [ -n "${PLATFORM}" ] && run_opts+=("--platform=${PLATFORM}")
 
-    if ! docker run "${run_opts[@]}" "${IMAGE_TAG}" "${probe_arg}" "${probe_val}" >/dev/null 2>&1; then
+    if ! docker run "${run_opts[@]}" "${IMAGE_TAG}" "${probe_arg}" >/dev/null 2>&1; then
         log_failure "Container failed to start when given server arguments"
-        docker logs "${probe}" 2>&1 | tail -20
+        docker logs "${probe}" 2>&1 | tail -20 || true
         docker rm -f "${probe}" >/dev/null 2>&1 || true
         exit 1
     fi
@@ -374,7 +382,7 @@ function check_arg_passthrough() {
         # Most likely cause is asd rejecting the forwarded flag, so show the logs
         # before the container goes away.
         log_failure "Could not locate asd process in container"
-        docker logs "${probe}" 2>&1 | tail -20
+        docker logs "${probe}" 2>&1 | tail -20 || true
         docker rm -f "${probe}" >/dev/null 2>&1 || true
         exit 1
     fi
@@ -383,34 +391,49 @@ function check_arg_passthrough() {
 
     # When the image's architecture is emulated (CI tests arm64 images on amd64
     # runners), binfmt prefixes argv with the emulator and the target binary:
-    #   /usr/bin/qemu-aarch64 /usr/bin/asd asd --config-file ... --fgdaemon
-    # Strip that prefix so the checks below still anchor on the real argv[0]. Do
-    # not relax them to a substring match instead: "/usr/bin/asd --config-file"
-    # would satisfy "asd --config-file" even if the entrypoint never prepended asd.
+    #   /usr/bin/qemu-aarch64 /usr/bin/asd asd --early-verbose --fgdaemon
+    # Strip that prefix so the comparison below still anchors on the real argv[0].
+    # Do not relax it to a substring match instead: "/usr/bin/asd --early-verbose"
+    # would satisfy a bare "asd --early-verbose" even with no asd prepended.
     local argv="${cmdline}"
     if [[ "${argv}" == /*qemu-* ]]; then
         argv="${argv#* }" # drop emulator path
         argv="${argv#* }" # drop target binary path
     fi
+    while [[ "${argv}" == *" " ]]; do argv="${argv% }"; done # NUL->space left a trailer
 
-    # Entrypoint prepends asd when the first argument starts with '-'.
-    if [[ "${argv}" != "asd "* ]]; then
-        log_failure "Expected asd argv to begin with 'asd', got: ${cmdline}"
-        exit 1
-    fi
-
-    if [[ "${argv}" != *"${probe_arg} ${probe_val}"* ]]; then
-        log_failure "Server argument not forwarded to asd: ${cmdline}"
-        exit 1
-    fi
-
-    # Entrypoint appends --fgdaemon so asd stays in the foreground under tini.
-    if [[ "${argv}" != *"--fgdaemon"* ]]; then
-        log_failure "Entrypoint did not append --fgdaemon: ${cmdline}"
+    # Compare the whole argv, not substrings. An exact match is what proves the
+    # entrypoint prepended asd, forwarded our flag, and appended --fgdaemon -- and
+    # it also catches arguments being injected, dropped, or reordered.
+    if [ "${argv}" != "${expect}" ]; then
+        log_failure "Unexpected asd argv"
+        log_failure "  expected: ${expect}"
+        log_failure "  actual:   ${cmdline}"
         exit 1
     fi
 
     log_success "Server arguments forwarded to asd"
+}
+
+# The entrypoint execs a first argument that is neither an option nor "asd" as the
+# container command (README documents `bash` giving a shell). check_arg_passthrough
+# covers the option branch and the default CMD ["asd"] covers the asd branch, so
+# without this the command branch is the one documented behavior with no coverage.
+function check_command_passthrough() {
+    log_info "Verifying non-option command passthrough..."
+
+    local run_opts=(--rm)
+    [ -n "${PLATFORM}" ] && run_opts+=("--platform=${PLATFORM}")
+
+    local out=""
+    out=$(docker run "${run_opts[@]}" "${IMAGE_TAG}" bash -c 'echo command-passthrough-ok' 2>/dev/null) || true
+
+    if [[ "${out}" != *command-passthrough-ok* ]]; then
+        log_failure "Entrypoint did not exec a non-option command as given: ${out:-<no output>}"
+        exit 1
+    fi
+
+    log_success "Non-option command exec'd as given"
 }
 
 # Optional first arg: "full" = also remove image when CLEAN=true (use after test).
@@ -418,6 +441,8 @@ function check_arg_passthrough() {
 function cleanup() {
     docker stop "${CONTAINER}" 2>/dev/null || true
     docker rm -f "${CONTAINER}" 2>/dev/null || true
+    # check_arg_passthrough's probe container, so an interrupt cannot leak a server.
+    docker rm -f "${CONTAINER}-args" 2>/dev/null || true
     if [ "${1:-}" = "full" ] && [ "${CLEAN}" = "true" ]; then
         docker rmi -f "${IMAGE_TAG}" 2>/dev/null || true
     fi
@@ -491,6 +516,7 @@ function test_specific_image() {
     run_docker
     check_container "${version}" "${EDITION}" "${arch_display}"
     check_arg_passthrough
+    check_command_passthrough
     run_snyk_scan "${IMAGE_TAG}" "${arch_display}" "" "${EDITION}" "${version}"
     cleanup full
 
@@ -583,6 +609,7 @@ function test_from_releases() {
                 run_docker
                 check_container "${version}" "${edition}" "${arch}"
                 check_arg_passthrough
+                check_command_passthrough
                 run_snyk_scan "${IMAGE_TAG}" "${arch}" "releases/${lineage}/${edition}/${distro}/Dockerfile" "${edition}" "${version}" "${distro}"
                 cleanup full
 

--- a/test.sh
+++ b/test.sh
@@ -342,15 +342,26 @@ function check_container() {
 # PID 1 is tini, so asd is located by scanning /proc (procps may not be in image).
 function check_arg_passthrough() {
     local probe="${CONTAINER}-args"
-    # The probe flag must be one the entrypoint could never emit on its own,
-    # otherwise the test proves nothing. --config-file is unusable here: its value
-    # would be both asd's default and the exact path the entrypoint writes the conf
-    # to, so an entrypoint that dropped "$@" and hardcoded that flag would produce a
-    # byte-identical argv and pass. --early-verbose is inert (verbose logging before
-    # config parse), is never synthesized by the entrypoint, and exists in every
-    # shipped lineage.
-    local probe_arg="--early-verbose"
-    local expect="asd ${probe_arg} --fgdaemon"
+    # Two properties make this probe able to fail:
+    #
+    # 1. The FIRST token must be one the entrypoint could never emit on its own,
+    #    otherwise the test proves nothing. --config-file cannot lead: its value here
+    #    is both asd's default and the exact path the entrypoint writes the conf to,
+    #    so an entrypoint that dropped "$@" and hardcoded that flag would produce a
+    #    byte-identical argv and pass. --early-verbose is inert (verbose logging
+    #    before config parse), is never synthesized by the entrypoint, and exists in
+    #    every shipped lineage.
+    # 2. More than one token, because "$@" and "$1" are indistinguishable at argc 1.
+    #    An entrypoint mutated to forward only its first argument would otherwise
+    #    pass -- and multi-token is the case orchestrators actually depend on, since
+    #    a flag with a value ("--preview yaml-config") is two argv tokens. Three
+    #    tokens also kills a "$1" "$2" mutation. --config-file is safe as a
+    #    non-leading token precisely because token 1 can no longer be synthesized,
+    #    and the entrypoint guarantees that path exists (it writes the conf there).
+    local probe_args=(--early-verbose --config-file /etc/aerospike/aerospike.conf)
+    # IFS is unmodified, so [*] joins with a single space -- matching the argv
+    # rendering the /proc scan below produces.
+    local expect="asd ${probe_args[*]} --fgdaemon"
 
     log_info "Verifying server argument passthrough..."
 
@@ -359,7 +370,7 @@ function check_arg_passthrough() {
     local run_opts=(-td --name "${probe}" -e "DEFAULT_TTL=30d")
     [ -n "${PLATFORM}" ] && run_opts+=("--platform=${PLATFORM}")
 
-    if ! docker run "${run_opts[@]}" "${IMAGE_TAG}" "${probe_arg}" >/dev/null 2>&1; then
+    if ! docker run "${run_opts[@]}" "${IMAGE_TAG}" "${probe_args[@]}" >/dev/null 2>&1; then
         log_failure "Container failed to start when given server arguments"
         docker logs "${probe}" 2>&1 | tail -20 || true
         docker rm -f "${probe}" >/dev/null 2>&1 || true
@@ -408,7 +419,10 @@ function check_arg_passthrough() {
     if [ "${argv}" != "${expect}" ]; then
         log_failure "Unexpected asd argv"
         log_failure "  expected: ${expect}"
-        log_failure "  actual:   ${cmdline}"
+        # Report the string that was actually compared, not the raw cmdline. Under
+        # emulation the raw form additionally differs by the two stripped prefix
+        # tokens, which would obscure the real mismatch.
+        log_failure "  actual:   ${argv}"
         exit 1
     fi
 

--- a/test.sh
+++ b/test.sh
@@ -333,6 +333,71 @@ function check_container() {
     fi
 }
 
+# Verify the entrypoint forwards server arguments to asd. This is a documented
+# interface (README: "Passing server command-line arguments") that container
+# orchestrators rely on to set server flags without replacing the entrypoint, so
+# it needs coverage against future entrypoint changes.
+# PID 1 is tini, so asd is located by scanning /proc (procps may not be in image).
+function check_arg_passthrough() {
+    local probe="${CONTAINER}-args"
+    # Benign flag: this is already the default path the entrypoint writes the conf to.
+    local probe_arg="--config-file"
+    local probe_val="/etc/aerospike/aerospike.conf"
+
+    log_info "Verifying server argument passthrough..."
+
+    docker rm -f "${probe}" >/dev/null 2>&1 || true
+
+    local run_opts=(-td --name "${probe}" -e "DEFAULT_TTL=30d")
+    [ -n "${PLATFORM}" ] && run_opts+=("--platform=${PLATFORM}")
+
+    if ! docker run "${run_opts[@]}" "${IMAGE_TAG}" "${probe_arg}" "${probe_val}" >/dev/null 2>&1; then
+        log_failure "Container failed to start when given server arguments"
+        docker logs "${probe}" 2>&1 | tail -20
+        docker rm -f "${probe}" >/dev/null 2>&1 || true
+        exit 1
+    fi
+
+    local find_asd='for p in /proc/[0-9]*; do [ "$(cat "$p/comm" 2>/dev/null)" = asd ] && { tr "\0" " " <"$p/cmdline"; exit 0; }; done; exit 1'
+
+    local cmdline=""
+    if try 15 docker exec "${probe}" bash -c "${find_asd}" >/dev/null 2>&1; then
+        # "|| true": asd can exit between the probe above and this call. Without it,
+        # errexit aborts before the cleanup below and leaks the probe container.
+        cmdline=$(docker exec "${probe}" bash -c "${find_asd}" 2>/dev/null | tr -d '\r') || true
+    fi
+
+    if [ -z "${cmdline}" ]; then
+        # Most likely cause is asd rejecting the forwarded flag, so show the logs
+        # before the container goes away.
+        log_failure "Could not locate asd process in container"
+        docker logs "${probe}" 2>&1 | tail -20
+        docker rm -f "${probe}" >/dev/null 2>&1 || true
+        exit 1
+    fi
+
+    docker rm -f "${probe}" >/dev/null 2>&1 || true
+
+    # Entrypoint prepends asd when the first argument starts with '-'.
+    if [[ "${cmdline}" != "asd "* ]]; then
+        log_failure "Expected asd argv to begin with 'asd', got: ${cmdline}"
+        exit 1
+    fi
+
+    if [[ "${cmdline}" != *"${probe_arg} ${probe_val}"* ]]; then
+        log_failure "Server argument not forwarded to asd: ${cmdline}"
+        exit 1
+    fi
+
+    # Entrypoint appends --fgdaemon so asd stays in the foreground under tini.
+    if [[ "${cmdline}" != *"--fgdaemon"* ]]; then
+        log_failure "Entrypoint did not append --fgdaemon: ${cmdline}"
+        exit 1
+    fi
+
+    log_success "Server arguments forwarded to asd"
+}
+
 # Optional first arg: "full" = also remove image when CLEAN=true (use after test).
 # No arg = container only (use before run_docker so we don't remove the image we're about to run).
 function cleanup() {
@@ -410,6 +475,7 @@ function test_specific_image() {
     cleanup
     run_docker
     check_container "${version}" "${EDITION}" "${arch_display}"
+    check_arg_passthrough
     run_snyk_scan "${IMAGE_TAG}" "${arch_display}" "" "${EDITION}" "${version}"
     cleanup full
 
@@ -501,6 +567,7 @@ function test_from_releases() {
                 cleanup
                 run_docker
                 check_container "${version}" "${edition}" "${arch}"
+                check_arg_passthrough
                 run_snyk_scan "${IMAGE_TAG}" "${arch}" "releases/${lineage}/${edition}/${distro}/Dockerfile" "${edition}" "${version}" "${distro}"
                 cleanup full
 

--- a/test.sh
+++ b/test.sh
@@ -381,19 +381,31 @@ function check_arg_passthrough() {
 
     docker rm -f "${probe}" >/dev/null 2>&1 || true
 
+    # When the image's architecture is emulated (CI tests arm64 images on amd64
+    # runners), binfmt prefixes argv with the emulator and the target binary:
+    #   /usr/bin/qemu-aarch64 /usr/bin/asd asd --config-file ... --fgdaemon
+    # Strip that prefix so the checks below still anchor on the real argv[0]. Do
+    # not relax them to a substring match instead: "/usr/bin/asd --config-file"
+    # would satisfy "asd --config-file" even if the entrypoint never prepended asd.
+    local argv="${cmdline}"
+    if [[ "${argv}" == /*qemu-* ]]; then
+        argv="${argv#* }" # drop emulator path
+        argv="${argv#* }" # drop target binary path
+    fi
+
     # Entrypoint prepends asd when the first argument starts with '-'.
-    if [[ "${cmdline}" != "asd "* ]]; then
+    if [[ "${argv}" != "asd "* ]]; then
         log_failure "Expected asd argv to begin with 'asd', got: ${cmdline}"
         exit 1
     fi
 
-    if [[ "${cmdline}" != *"${probe_arg} ${probe_val}"* ]]; then
+    if [[ "${argv}" != *"${probe_arg} ${probe_val}"* ]]; then
         log_failure "Server argument not forwarded to asd: ${cmdline}"
         exit 1
     fi
 
     # Entrypoint appends --fgdaemon so asd stays in the foreground under tini.
-    if [[ "${cmdline}" != *"--fgdaemon"* ]]; then
+    if [[ "${argv}" != *"--fgdaemon"* ]]; then
         log_failure "Entrypoint did not append --fgdaemon: ${cmdline}"
         exit 1
     fi


### PR DESCRIPTION
## Summary

SERVER-1389 asks how container orchestrators (AKO) should enable server flags such as `--preview`. While investigating, it turned out `entrypoint.sh` **already** forwards arbitrary arguments to `asd` — no image change is needed to support this use case.

This PR therefore makes that existing behavior a **documented, tested contract** rather than incidental behavior that a future entrypoint refactor could silently break. There is no functional change to the entrypoint.

## Background

The AKO team is adding a `previewFeatures` field to the `AerospikeCluster` CR and asked which mechanism the image should offer: overriding `CMD`, an entrypoint env-var shim, or native env support in the server. A short-term "add `--preview` to entrypoint.sh" mitigation was proposed.

That mitigation is unnecessary. The image is:

```
ENTRYPOINT ["/usr/bin/as-tini-static", "-r", "SIGUSR1", "-t", "SIGTERM", "--", "/entrypoint.sh"]
CMD ["asd"]
```

and `entrypoint.sh` already contains:

```bash
# if command starts with an option, prepend asd
if [ "${1:0:1}" = '-' ]; then
    set -- asd "$@"
fi
```

So setting `args: ["--some-flag"]` in a pod spec replaces `CMD`, the entrypoint prepends `asd`, appends `--fgdaemon`, and execs. Orchestrators need to pass **only the flags**, not reconstruct the command line. This works on every image carrying this entrypoint — no new image, no minimum-version gate.

The gap was that this was never documented or covered by a test.

## Changes

**`README.md`**
- New `### Passing server command-line arguments` section under Advanced Configuration, plus a TOC entry.
- Documents the `asd` prepend, the `--fgdaemon` append, and that a first argument not starting with `-` runs as the container command instead (`bash` gives a shell).
- `docker run` and Kubernetes `args:` examples.
- States that available flags vary by server version and to check `asd --help` for the target image.
- Clarifies that env vars are **not** translated into arguments — the existing template variables feed the config template only.

**`test.sh`**
- New `check_arg_passthrough` and `check_command_passthrough`, wired into both `test_specific_image` and `test_from_releases`.
- `check_arg_passthrough` starts a throwaway probe container with `--early-verbose` and compares `asd`'s **entire actual argv** against `asd --early-verbose --fgdaemon`.
  - The probe flag must be one the entrypoint could never emit on its own. An earlier revision used `--config-file /etc/aerospike/aerospike.conf`, which is both asd's default *and* the path the entrypoint writes the conf to — an entrypoint that dropped `"$@"` and hardcoded it produced a byte-identical argv and passed. See Verification below.
  - Exact match rather than substrings, so injected/dropped/reordered arguments are caught too.
- `check_command_passthrough` covers the non-option command branch (`bash` → shell). The option branch is covered above and the default `CMD ["asd"]` covers the `asd` branch, so this was the one documented behavior with no coverage.
- PID 1 is `as-tini-static`, not `asd`, so the probe locates `asd` by scanning `/proc` for `comm == asd` rather than reading `/proc/1/cmdline`. It avoids `pgrep` because `procps` is not present in every image (`check_container` already has this caveat).

**`template/0/entrypoint.sh`** (+ the 24 byte-identical `releases/*/entrypoint.sh` copies)
- Comment only, no logic change — marks the argument-forwarding block as a depended-on interface so it survives future refactors. Propagated to `releases/` so a subsequent `docker-build.sh` refresh does not produce a spurious 24-file diff.

## Verification

Run against `aerospike-server-enterprise:8.1.3.0`:

**Mutation-tested.** A mutant image whose entrypoint discards `"$@"` (`set -- asd --config-file /etc/aerospike/aerospike.conf`) — i.e. forwarding completely dead:

| Image | Result |
| --- | --- |
| Good (forwarding intact) | **PASS** |
| Mutant (forwarding dead) | **FAIL** — `expected: asd --early-verbose --fgdaemon` / `actual: asd --config-file /etc/aerospike/aerospike.conf --fgdaemon` |

That mutant passed an earlier revision of this PR. Other checks:

| Check | Result |
| --- | --- |
| PID 1 | `as-tini-static ... -- /entrypoint.sh ...` — confirms the `/proc` scan is required |
| `asd --early-verbose` (explicit-asd branch) | argv `asd --early-verbose --fgdaemon`, identical to the option branch — confirms the README's 3-way dispatch |
| `check_command_passthrough` | `bash -c` output returned, non-option branch exec'd as given |
| Probe container cleanup | no leaks, including on failure paths and via `cleanup()` on interrupt |
| `bash -n` on both scripts | clean |
| CI `Build and test` | green on 4 lineages x 2 arches (incl. emulated arm64), which also confirms `--early-verbose` exists in every shipped lineage |

`shellcheck` was not available locally; CI covers it via `reviewdog/action-shellcheck`.

## Reviewer notes

**The README example deliberately does not use `--preview`.** Testing surfaced that the flag was renamed between versions:

| Versions | Flag | Valid values |
| --- | --- | --- |
| 7.1, 7.2, 8.0, 8.1.2 — every lineage this repo builds | `--experimental` (no argument) | n/a |
| `origin/master` / 8.1.3.0 (unreleased) | `--preview <feature>[,<feature>...]` | `yaml-config` only |

Two consequences:

1. `README.md` is a single file describing **all** published tags, none of which currently accept `--preview`. An example using it would exit 1 for every reader.
2. The one valid value cannot be demonstrated in this image anyway — `--preview yaml-config` makes `asd` expect a YAML config, but the entrypoint generates a classic-format `aerospike.conf`:
   ```
   CRITICAL (config): (cfg.c:2169) error while validating config file:
   Validation error: ... unexpected instance type
   ```

So the section uses `--early-verbose`, which exists in every version and is verified working. A `--preview` example can be added once a preview feature ships in a released image and works against the default generated config.

This rename is also worth flagging on SERVER-1389 itself: it is a concrete instance of the version-skew concern raised in the originating thread, and adding an `AEROSPIKE_PREVIEW` env var would not address it, since the env var carries the same feature-name strings. The thread also assumes a feature named `index-checkpoint`, which no build currently accepts.


